### PR TITLE
(feat) Filter forms by privileges

### DIFF
--- a/src/forms-page/FormsPage.tsx
+++ b/src/forms-page/FormsPage.tsx
@@ -7,6 +7,20 @@ import FormsTable from "../forms-table";
 import styles from "./styles.scss";
 import { useTranslation } from "react-i18next";
 
+// helper function to check which permissions affect which forms
+// useful for debugging
+const getFormPermissions = (forms) => {
+  const output = {};
+  forms?.forEach(
+    (form) =>
+      (output[form.encounterType.editPrivilege.display] = [
+        ...(output[form.encounterType.editPrivilege.display] || []),
+        form.display,
+      ])
+  );
+  return output;
+};
+
 const filterByPermissions = (rowFormData, user) => {
   if (rowFormData) {
     return rowFormData.filter((form) => {
@@ -21,6 +35,7 @@ const prepareRowsForTable = (rawFormData) => {
     return rawFormData?.map((form) => ({
       ...form,
       id: form.uuid,
+      display: form.display || form.name,
     }));
   }
   return null;
@@ -50,11 +65,15 @@ const FormsPage = () => {
     <div className={styles.mainContent}>
       <h3 className={styles.pageTitle}>{t("forms", "Forms")}</h3>
       <Tabs type="container">
-        <Tab label={t("allForms", "All Forms")}>
+        <Tab
+          label={`${t("allForms", "All Forms")} (${
+            cleanRows ? cleanRows?.length : "??"
+          })`}
+        >
           <FormsTable rows={cleanRows} {...{ error, isLoading }} />
         </Tab>
         {categoryRows?.map((category, index) => (
-          <Tab label={category.name} key={index}>
+          <Tab label={`${category.name} (${category.rows.length})`} key={index}>
             <FormsTable rows={category.rows} {...{ error, isLoading }} />
           </Tab>
         ))}

--- a/src/forms-page/FormsPage.tsx
+++ b/src/forms-page/FormsPage.tsx
@@ -1,4 +1,4 @@
-import { useConfig, userHasAccess, useSession } from "@openmrs/esm-framework";
+import { useConfig } from "@openmrs/esm-framework";
 import { Tab, Tabs } from "carbon-components-react";
 import React from "react";
 import { Config } from "../config-schema";
@@ -7,8 +7,9 @@ import FormsTable from "../forms-table";
 import styles from "./styles.scss";
 import { useTranslation } from "react-i18next";
 
-// helper function to check which permissions affect which forms
-// useful for debugging
+// helper function useful for debugging
+// given a list of forms, it will organize into permissions
+// and list which forms are associated with that permission
 const getFormPermissions = (forms) => {
   const output = {};
   forms?.forEach(
@@ -21,15 +22,8 @@ const getFormPermissions = (forms) => {
   return output;
 };
 
-const filterByPermissions = (rowFormData, user) => {
-  if (rowFormData) {
-    return rowFormData.filter((form) => {
-      return !!userHasAccess(form.encounterType?.editPrivilege?.display, user);
-    });
-  }
-};
-
 // Function adds `id` field to rows so they will be accepted by DataTable
+// "display" is prefered for display name if present, otherwise fall back on "name'"
 const prepareRowsForTable = (rawFormData) => {
   if (rawFormData) {
     return rawFormData?.map((form) => ({
@@ -46,10 +40,7 @@ const FormsPage = () => {
   const { t } = useTranslation();
   const { formCategories, formCategoriesToShow } = config;
   const { forms, isLoading, error } = useGetAllForms();
-  const session = useSession();
-  const cleanRows = prepareRowsForTable(
-    filterByPermissions(forms, session.user)
-  );
+  const cleanRows = prepareRowsForTable(forms);
 
   const categoryRows = formCategoriesToShow.map((name) => {
     const category = formCategories.find((category) => category.name === name);

--- a/src/forms-table/FormsTable.tsx
+++ b/src/forms-table/FormsTable.tsx
@@ -23,7 +23,7 @@ const FormsTable = ({ rows, error, isLoading }) => {
 
   const formsHeader = [
     {
-      key: "name",
+      key: "display",
       header: t("formName", "Form Name"),
     },
     {

--- a/src/hooks/useGetAllForms.ts
+++ b/src/hooks/useGetAllForms.ts
@@ -24,21 +24,19 @@ export function useGetAllForms(cachedOfflineFormsOnly = false) {
           // forms should be published
           form.published &&
           // forms should not be component forms
-          !/component/i.test(form.name) &&
-          // user should have privileges to edit forms
-          Boolean(
-            userHasAccess(
-              form.encounterType?.editPrivilege?.display,
-              session?.user
-            )
-          )
+          !/component/i.test(form.name)
+        // user should have privileges to edit forms
       ) ?? [];
 
     return forms;
   });
 
   return {
-    forms: data,
+    forms: data?.filter((form) =>
+      Boolean(
+        userHasAccess(form.encounterType?.editPrivilege?.display, session?.user)
+      )
+    ),
     isLoading: !error && !data,
     error,
   };

--- a/src/hooks/useGetAllForms.ts
+++ b/src/hooks/useGetAllForms.ts
@@ -1,4 +1,8 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import {
+  openmrsFetch,
+  userHasAccess,
+  useSession,
+} from "@openmrs/esm-framework";
 import useSWR from "swr";
 
 const customFormRepresentation =
@@ -8,14 +12,26 @@ const formEncounterUrl = `/ws/rest/v1/form?v=custom:${customFormRepresentation}`
 const formEncounterUrlPoc = `/ws/rest/v1/form?v=custom:${customFormRepresentation}&q=poc`;
 
 export function useGetAllForms(cachedOfflineFormsOnly = false) {
+  const session = useSession();
   const showHtmlFormEntryForms = true;
   const url = showHtmlFormEntryForms ? formEncounterUrl : formEncounterUrlPoc;
   const { data, error } = useSWR([url, cachedOfflineFormsOnly], async () => {
     const res = await openmrsFetch(url);
-    // show published forms and hide component forms
+    // show published forms, and hide component forms, and filter based on privileges
     const forms =
       res.data?.results?.filter(
-        (form) => form.published && !/component/i.test(form.name)
+        (form) =>
+          // forms should be published
+          form.published &&
+          // forms should not be component forms
+          !/component/i.test(form.name) &&
+          // user should have privileges to edit forms
+          Boolean(
+            userHasAccess(
+              form.encounterType?.editPrivilege?.display,
+              session?.user
+            )
+          )
       ) ?? [];
 
     return forms;


### PR DESCRIPTION
This implements a frontend filter for which forms are shown to a user based on which edit privileges they have
Completes TFS 319173

Screenshots show new (count) display. Super user shows all 75 forms, user with some roles and privileges shows 49 available forms. 

![Screen Shot 2022-07-18 at 11 40 09 PM](https://user-images.githubusercontent.com/5445264/179683183-178a535b-cfad-47eb-8c2b-0419291217cb.png)

![Screen Shot 2022-07-18 at 11 38 33 PM](https://user-images.githubusercontent.com/5445264/179683210-b4dda425-f14b-422b-8000-62ad1921f21b.png)

 