### PR TITLE
(fix) Rename app menu link component

### DIFF
--- a/src/forms-app-menu-link.tsx
+++ b/src/forms-app-menu-link.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { ConfigurableLink } from "@openmrs/esm-framework";
 
-export default function OfflineToolsAppMenuLink() {
+export default function FormsAppMenuLink() {
   const { t } = useTranslation();
   return (
     // eslint-disable-next-line


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR renames the app menu link component from `OfflineToolsAppMenuLink` to `FormsAppMenuLink`.