### PR TITLE
(fix) Left align form labels

### DIFF
--- a/src/form-entry-workflow/styles.scss
+++ b/src/form-entry-workflow/styles.scss
@@ -36,6 +36,7 @@
   flex-grow: 1;
   max-height: calc(100vh - 14rem);
   overflow-y: scroll;
+  text-align: left;
 }
 
 .formContainer :global(.cds--form-item) :global(.question-area) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Sets form to `text-align: left` 

## Screenshots
Before:

![Screen Shot 2022-10-07 at 8 00 04 AM](https://user-images.githubusercontent.com/5445264/194585096-57acf7b0-50f9-4c1e-8b05-401080759565.png)

After:

![Screen Shot 2022-10-07 at 7 59 51 AM](https://user-images.githubusercontent.com/5445264/194585124-eac2315a-e244-460c-ae94-465b856aeaae.png)

## Related Issue
[TFS-346410](https://tfs.ext.icrc.org/ICRCCollection/Pearlii/_sprints/backlog/Mekom/Pearlii/Application/EMR/Mekom/2022/2022%20Sprint%2019?workitem=346410)

## Other
<!-- Anything not covered above -->
