### PR TITLE
(feat) Save and load distinct workflows per logged user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,21 @@ jobs:
           name: dist
           path: |
             dist
+  
+  deploy_fast_data_entry_app:
+    runs-on: ubuntu-latest
+
+    needs: pre_release
+
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Trigger RefApp Build
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: https://ci.openmrs.org/rest/api/latest/queue/REFAPP-D3X
+          method: "POST"
+          customHeaders: '{ "Authorization": "Bearer ${{ secrets.BAMBOO_TOKEN }}" }'
 
   release:
     runs-on: ubuntu-latest
@@ -88,36 +103,3 @@ jobs:
       - run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" &&  yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-  deploy_fast_data_entry_app:
-    runs-on: ubuntu-latest
-
-    env:
-      DIR_NAME: "esm-fast-data-entry-app"
-      ESM_NAME: "@openmrs/esm-fast-data-entry-app"
-      JS_NAME: "openmrs-esm-fast-data-entry-app.js"
-
-    needs: pre_release
-
-    if: ${{ github.event_name == 'push' }}
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-      - name: Compute Timestamp
-        run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Prepare Directory
-        shell: bash
-        run: |
-          mkdir -p publish/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}
-          mv dist/*.* publish/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}/
-      - name: Publish to Digital Ocean
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --cache-control "max-age=31536000"
-        env:
-          AWS_S3_BUCKET: ${{ secrets.DIGITAL_OCEAN_SPACES_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DIGITAL_OCEAN_SPACES_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DIGITAL_OCEAN_SPACES_ACCESS_KEY }}
-          AWS_S3_ENDPOINT: ${{ secrets.DIGITAL_OCEAN_SPACES_ENDPOINT }}
-          SOURCE_DIR: "publish"

--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { detach, ExtensionSlot } from "@openmrs/esm-framework";
 import useGetPatient from "./hooks/useGetPatient";
+import { detachAll } from "@openmrs/esm-extensions/src/extensions";
 
 export interface Order {
   uuid: string;
@@ -123,7 +124,9 @@ const FormBootstrap = ({
   const patient = useGetPatient(patientUuid);
 
   useEffect(() => {
-    return () => detach("form-widget-slot", "form-widget-slot");
+    return () => {
+      detach("form-widget-slot", "form-widget-slot");
+    };
   });
 
   return (

--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -130,7 +130,7 @@ const FormBootstrap = ({
     <div>
       {formUuid && patientUuid && patient && (
         <ExtensionSlot
-          extensionSlotName="form-widget-slot"
+          name="form-widget-slot"
           state={{
             view: "form",
             formUuid,

--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { detach, ExtensionSlot } from "@openmrs/esm-framework";
 import useGetPatient from "./hooks/useGetPatient";
-import { detachAll } from "@openmrs/esm-extensions/src/extensions";
 
 export interface Order {
   uuid: string;
@@ -124,9 +123,7 @@ const FormBootstrap = ({
   const patient = useGetPatient(patientUuid);
 
   useEffect(() => {
-    return () => {
-      detach("form-widget-slot", "form-widget-slot");
-    };
+    return () => detach("form-widget-slot", "form-widget-slot");
   });
 
   return (

--- a/src/context/FormWorkflowContext.tsx
+++ b/src/context/FormWorkflowContext.tsx
@@ -11,11 +11,9 @@ const initialActions = {
   openPatientSearch: () => undefined,
   saveEncounter: (encounterUuid: string | number) => undefined,
   editEncounter: (patientUuid: string | number) => undefined,
-  updateVisitUuid: (visitUuid: string) => undefined,
   submitForNext: () => undefined,
   submitForReview: () => undefined,
   submitForComplete: () => undefined,
-  validateForComplete: () => undefined,
   goToReview: () => undefined,
   destroySession: () => undefined,
   closeSession: () => undefined,
@@ -31,7 +29,6 @@ export const initialWorkflowState = {
   workflowState: null, // pseudo field from state[activeFormUuid].workflowState
   activePatientUuid: null, // pseudo field from state[activeFormUuid].activePatientUuid
   activeEncounterUuid: null, // pseudo field from state[activeFormUuid].encounterUuid
-  activeVisitUuid: null, // pseudo field from state[activeFormUuid].activeVisitUuid
   patientUuids: [], // pseudo field from state[activeFormUuid].patientUuids
   encounters: {}, // pseudo field from state[activeFormUuid].encounters
   singleSessionVisitTypeUuid: null,
@@ -73,12 +70,9 @@ const FormWorkflowProvider = ({ children }) => {
           type: "SAVE_ENCOUNTER",
           encounterUuid,
         }),
-      updateVisitUuid: (visitUuid) =>
-        dispatch({ type: "UPDATE_VISIT_UUID", visitUuid }),
       submitForNext: () => dispatch({ type: "SUBMIT_FOR_NEXT" }),
       submitForReview: () => dispatch({ type: "SUBMIT_FOR_REVIEW" }),
       submitForComplete: () => dispatch({ type: "SUBMIT_FOR_COMPLETE" }),
-      validateForComplete: () => dispatch({ type: "VALIDATE_FOR_COMPLETE" }),
       editEncounter: (patientUuid) =>
         dispatch({ type: "EDIT_ENCOUNTER", patientUuid }),
       goToReview: () => dispatch({ type: "GO_TO_REVIEW" }),
@@ -99,7 +93,6 @@ const FormWorkflowProvider = ({ children }) => {
   return (
     <FormWorkflowContext.Provider
       value={{
-        singleSessionVisitTypeUuid,
         ...state,
         ...actions,
         workflowState:
@@ -111,9 +104,6 @@ const FormWorkflowProvider = ({ children }) => {
         activeEncounterUuid:
           state.forms?.[state.activeFormUuid]?.activeEncounterUuid ??
           initialWorkflowState.activeEncounterUuid,
-        activeVisitUuid:
-          state.forms?.[state.activeFormUuid]?.activeVisitUuid ??
-          initialWorkflowState.activeVisitUuid,
         patientUuids:
           state.forms?.[state.activeFormUuid]?.patientUuids ??
           initialWorkflowState.patientUuids,

--- a/src/context/FormWorkflowContext.tsx
+++ b/src/context/FormWorkflowContext.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useReducer } from "react";
 import reducer from "./FormWorkflowReducer";
 import { useParams, useLocation } from "react-router-dom";
+import useGetSystemSetting from "../hooks/useGetSystemSetting";
 interface ParamTypes {
   formUuid?: string;
 }
@@ -30,6 +31,7 @@ export const initialWorkflowState = {
   activeEncounterUuid: null, // pseudo field from state[activeFormUuid].encounterUuid
   patientUuids: [], // pseudo field from state[activeFormUuid].patientUuids
   encounters: {}, // pseudo field from state[activeFormUuid].encounters
+  singleSessionVisitTypeUuid: null,
 };
 
 const FormWorkflowContext = React.createContext({
@@ -46,6 +48,11 @@ const FormWorkflowProvider = ({ children }) => {
     ...initialWorkflowState,
     ...initialActions,
   });
+  const systemSetting = useGetSystemSetting(
+    "@openmrs/esm-fast-data-entry-app.groupSessionVisitTypeUuid"
+  );
+  const singleSessionVisitTypeUuid =
+    systemSetting?.result?.data?.results?.[0]?.value;
 
   const actions = useMemo(
     () => ({
@@ -103,6 +110,7 @@ const FormWorkflowProvider = ({ children }) => {
         encounters:
           state.forms?.[state.activeFormUuid]?.encounters ??
           initialWorkflowState.encounters,
+        singleSessionVisitTypeUuid,
       }}
     >
       {children}

--- a/src/context/FormWorkflowContext.tsx
+++ b/src/context/FormWorkflowContext.tsx
@@ -11,9 +11,11 @@ const initialActions = {
   openPatientSearch: () => undefined,
   saveEncounter: (encounterUuid: string | number) => undefined,
   editEncounter: (patientUuid: string | number) => undefined,
+  updateVisitUuid: (visitUuid: string) => undefined,
   submitForNext: () => undefined,
   submitForReview: () => undefined,
   submitForComplete: () => undefined,
+  validateForComplete: () => undefined,
   goToReview: () => undefined,
   destroySession: () => undefined,
   closeSession: () => undefined,
@@ -29,6 +31,7 @@ export const initialWorkflowState = {
   workflowState: null, // pseudo field from state[activeFormUuid].workflowState
   activePatientUuid: null, // pseudo field from state[activeFormUuid].activePatientUuid
   activeEncounterUuid: null, // pseudo field from state[activeFormUuid].encounterUuid
+  activeVisitUuid: null, // pseudo field from state[activeFormUuid].activeVisitUuid
   patientUuids: [], // pseudo field from state[activeFormUuid].patientUuids
   encounters: {}, // pseudo field from state[activeFormUuid].encounters
   singleSessionVisitTypeUuid: null,
@@ -70,9 +73,12 @@ const FormWorkflowProvider = ({ children }) => {
           type: "SAVE_ENCOUNTER",
           encounterUuid,
         }),
+      updateVisitUuid: (visitUuid) =>
+        dispatch({ type: "UPDATE_VISIT_UUID", visitUuid }),
       submitForNext: () => dispatch({ type: "SUBMIT_FOR_NEXT" }),
       submitForReview: () => dispatch({ type: "SUBMIT_FOR_REVIEW" }),
       submitForComplete: () => dispatch({ type: "SUBMIT_FOR_COMPLETE" }),
+      validateForComplete: () => dispatch({ type: "VALIDATE_FOR_COMPLETE" }),
       editEncounter: (patientUuid) =>
         dispatch({ type: "EDIT_ENCOUNTER", patientUuid }),
       goToReview: () => dispatch({ type: "GO_TO_REVIEW" }),
@@ -93,6 +99,7 @@ const FormWorkflowProvider = ({ children }) => {
   return (
     <FormWorkflowContext.Provider
       value={{
+        singleSessionVisitTypeUuid,
         ...state,
         ...actions,
         workflowState:
@@ -104,6 +111,9 @@ const FormWorkflowProvider = ({ children }) => {
         activeEncounterUuid:
           state.forms?.[state.activeFormUuid]?.activeEncounterUuid ??
           initialWorkflowState.activeEncounterUuid,
+        activeVisitUuid:
+          state.forms?.[state.activeFormUuid]?.activeVisitUuid ??
+          initialWorkflowState.activeVisitUuid,
         patientUuids:
           state.forms?.[state.activeFormUuid]?.patientUuids ??
           initialWorkflowState.patientUuids,

--- a/src/context/FormWorkflowContext.tsx
+++ b/src/context/FormWorkflowContext.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useReducer } from "react";
 import reducer from "./FormWorkflowReducer";
 import { useParams, useLocation } from "react-router-dom";
 import useGetSystemSetting from "../hooks/useGetSystemSetting";
+import { useSession } from "@openmrs/esm-framework";
 interface ParamTypes {
   formUuid?: string;
 }
@@ -32,6 +33,7 @@ export const initialWorkflowState = {
   patientUuids: [], // pseudo field from state[activeFormUuid].patientUuids
   encounters: {}, // pseudo field from state[activeFormUuid].encounters
   singleSessionVisitTypeUuid: null,
+  userId: null,
 };
 
 const FormWorkflowContext = React.createContext({
@@ -40,6 +42,7 @@ const FormWorkflowContext = React.createContext({
 });
 
 const FormWorkflowProvider = ({ children }) => {
+  const { user } = useSession();
   const { formUuid } = useParams() as ParamTypes;
   const activeFormUuid = formUuid.split("&")[0];
   const { search } = useLocation();
@@ -61,6 +64,7 @@ const FormWorkflowProvider = ({ children }) => {
           type: "INITIALIZE_WORKFLOW_STATE",
           activeFormUuid,
           newPatientUuid,
+          userId: user.username,
         }),
       addPatient: (patientUuid) =>
         dispatch({ type: "ADD_PATIENT", patientUuid }),
@@ -79,7 +83,7 @@ const FormWorkflowProvider = ({ children }) => {
       destroySession: () => dispatch({ type: "DESTROY_SESSION" }),
       closeSession: () => dispatch({ type: "CLOSE_SESSION" }),
     }),
-    []
+    [user]
   );
 
   // if formUuid isn't a part of state yet, grab it from the url params

--- a/src/context/FormWorkflowReducer.ts
+++ b/src/context/FormWorkflowReducer.ts
@@ -3,8 +3,11 @@ import { initialWorkflowState } from "./FormWorkflowContext";
 
 export const fdeWorkflowStorageVersion = "1.0.13";
 export const fdeWorkflowStorageName = "openmrs:fastDataEntryWorkflowState";
-const persistData = (data) => {
-  localStorage.setItem(fdeWorkflowStorageName, JSON.stringify(data));
+const persistData = (data, userId) => {
+  localStorage.setItem(
+    fdeWorkflowStorageName + ":" + userId,
+    JSON.stringify(data)
+  );
 };
 
 const initialFormState = {
@@ -18,7 +21,9 @@ const initialFormState = {
 const reducer = (state, action) => {
   switch (action.type) {
     case "INITIALIZE_WORKFLOW_STATE": {
-      const savedData = localStorage.getItem(fdeWorkflowStorageName);
+      const savedData = localStorage.getItem(
+        fdeWorkflowStorageName + ":" + action.userId
+      );
       const savedDataObject = savedData ? JSON.parse(savedData) : {};
       let newState: { [key: string]: unknown } = {};
       const newPatient = action.newPatientUuid
@@ -69,9 +74,10 @@ const reducer = (state, action) => {
             [action.activeFormUuid]: initialFormState,
           },
           activeFormUuid: action.activeFormUuid,
+          userId: action.userId,
         };
       }
-      persistData(newState);
+      persistData(newState, action.userId);
       return { ...newState };
     }
     case "ADD_PATIENT": {
@@ -91,7 +97,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "OPEN_PATIENT_SEARCH": {
@@ -108,7 +114,7 @@ const reducer = (state, action) => {
         },
       };
       // the persist here is optional...
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "SAVE_ENCOUNTER": {
@@ -122,7 +128,7 @@ const reducer = (state, action) => {
           forms: formRest,
           activeFormUuid: null,
         };
-        persistData(newState);
+        persistData(newState, state.userId);
         // eslint-disable-next-line
         navigate({ to: "${openmrsSpaBase}/forms" });
         return newState;
@@ -151,7 +157,7 @@ const reducer = (state, action) => {
             },
           },
         };
-        persistData(newState);
+        persistData(newState, state.userId);
         return newState;
       }
     }
@@ -169,7 +175,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "SUBMIT_FOR_NEXT":
@@ -248,7 +254,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "DESTROY_SESSION": {
@@ -258,7 +264,7 @@ const reducer = (state, action) => {
         forms: formRest,
         activeFormUuid: null,
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       //eslint-disable-next-line
       navigate({ to: "${openmrsSpaBase}/forms" });
       return newState;
@@ -268,7 +274,7 @@ const reducer = (state, action) => {
         ...state,
         activeFormUuid: null,
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       //eslint-disable-next-line
       navigate({ to: "${openmrsSpaBase}/forms" });
       return newState;

--- a/src/context/FormWorkflowReducer.ts
+++ b/src/context/FormWorkflowReducer.ts
@@ -11,7 +11,6 @@ const initialFormState = {
   workflowState: "NEW_PATIENT",
   activePatientUuid: null,
   activeEncounterUuid: null,
-  activeVisitUuid: null,
   patientUuids: [],
   encounters: {},
 };
@@ -128,14 +127,6 @@ const reducer = (state, action) => {
         navigate({ to: "${openmrsSpaBase}/forms" });
         return newState;
       } else {
-        const thisForm = state.forms[state.activeFormUuid];
-        const nextPatientUuid =
-          thisForm.patientUuids[
-            Math.min(
-              thisForm.patientUuids.indexOf(thisForm.activePatientUuid) + 1,
-              thisForm.patientUuids.length - 1
-            )
-          ];
         const newState = {
           ...state,
           forms: {
@@ -149,9 +140,6 @@ const reducer = (state, action) => {
               },
               activePatientUuid: null,
               activeEncounterUuid: null,
-              activeVisitUuid:
-                state.forms[state.activeFormUuid].visits[nextPatientUuid] ||
-                null,
               workflowState:
                 state.forms[state.activeFormUuid].workflowState ===
                 "SUBMIT_FOR_NEXT"
@@ -226,29 +214,7 @@ const reducer = (state, action) => {
           },
         },
       };
-    case "VALIDATE_FOR_COMPLETE":
-      // this state should not be persisted
-      window.dispatchEvent(
-        new CustomEvent("ampath-form-action", {
-          detail: {
-            formUuid: state.activeFormUuid,
-            patientUuid: state.forms[state.activeFormUuid].activePatientUuid,
-            action: "validateForm",
-          },
-        })
-      );
-      return {
-        ...state,
-        forms: {
-          ...state.forms,
-          [state.activeFormUuid]: {
-            ...state.forms[state.activeFormUuid],
-            workflowState: "VALIDATE_FOR_COMPLETE",
-          },
-        },
-      };
     case "SUBMIT_FOR_COMPLETE":
-      console.log("SUBMIT_FOR_COMPLETE");
       // this state should not be persisted
       window.dispatchEvent(
         new CustomEvent("ampath-form-action", {
@@ -307,24 +273,6 @@ const reducer = (state, action) => {
       navigate({ to: "${openmrsSpaBase}/forms" });
       return newState;
     }
-    case "UPDATE_VISIT_UUID":
-      // this state should not be persisted
-      // we don't pers
-      return {
-        ...state,
-        forms: {
-          ...state.forms,
-          [state.activeFormUuid]: {
-            ...state.forms[state.activeFormUuid],
-            visits: {
-              ...state.forms[state.activeFormUuid]?.visits,
-              [state.forms[state.activeFormUuid].activePatientUuid]:
-                action.visitUuid,
-            },
-            activeVisitUuid: JSON.parse(JSON.stringify(action.visitUuid)),
-          },
-        },
-      };
     default:
       return state;
   }

--- a/src/context/FormWorkflowReducer.ts
+++ b/src/context/FormWorkflowReducer.ts
@@ -11,6 +11,7 @@ const initialFormState = {
   workflowState: "NEW_PATIENT",
   activePatientUuid: null,
   activeEncounterUuid: null,
+  activeVisitUuid: null,
   patientUuids: [],
   encounters: {},
 };
@@ -127,6 +128,14 @@ const reducer = (state, action) => {
         navigate({ to: "${openmrsSpaBase}/forms" });
         return newState;
       } else {
+        const thisForm = state.forms[state.activeFormUuid];
+        const nextPatientUuid =
+          thisForm.patientUuids[
+            Math.min(
+              thisForm.patientUuids.indexOf(thisForm.activePatientUuid) + 1,
+              thisForm.patientUuids.length - 1
+            )
+          ];
         const newState = {
           ...state,
           forms: {
@@ -140,6 +149,9 @@ const reducer = (state, action) => {
               },
               activePatientUuid: null,
               activeEncounterUuid: null,
+              activeVisitUuid:
+                state.forms[state.activeFormUuid].visits[nextPatientUuid] ||
+                null,
               workflowState:
                 state.forms[state.activeFormUuid].workflowState ===
                 "SUBMIT_FOR_NEXT"
@@ -214,7 +226,29 @@ const reducer = (state, action) => {
           },
         },
       };
+    case "VALIDATE_FOR_COMPLETE":
+      // this state should not be persisted
+      window.dispatchEvent(
+        new CustomEvent("ampath-form-action", {
+          detail: {
+            formUuid: state.activeFormUuid,
+            patientUuid: state.forms[state.activeFormUuid].activePatientUuid,
+            action: "validateForm",
+          },
+        })
+      );
+      return {
+        ...state,
+        forms: {
+          ...state.forms,
+          [state.activeFormUuid]: {
+            ...state.forms[state.activeFormUuid],
+            workflowState: "VALIDATE_FOR_COMPLETE",
+          },
+        },
+      };
     case "SUBMIT_FOR_COMPLETE":
+      console.log("SUBMIT_FOR_COMPLETE");
       // this state should not be persisted
       window.dispatchEvent(
         new CustomEvent("ampath-form-action", {
@@ -273,6 +307,24 @@ const reducer = (state, action) => {
       navigate({ to: "${openmrsSpaBase}/forms" });
       return newState;
     }
+    case "UPDATE_VISIT_UUID":
+      // this state should not be persisted
+      // we don't pers
+      return {
+        ...state,
+        forms: {
+          ...state.forms,
+          [state.activeFormUuid]: {
+            ...state.forms[state.activeFormUuid],
+            visits: {
+              ...state.forms[state.activeFormUuid]?.visits,
+              [state.forms[state.activeFormUuid].activePatientUuid]:
+                action.visitUuid,
+            },
+            activeVisitUuid: JSON.parse(JSON.stringify(action.visitUuid)),
+          },
+        },
+      };
     default:
       return state;
   }

--- a/src/context/GroupFormWorkflowContext.tsx
+++ b/src/context/GroupFormWorkflowContext.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useReducer } from "react";
 import reducer from "./GroupFormWorkflowReducer";
 import { useParams } from "react-router-dom";
-import { Type } from "@openmrs/esm-framework";
+import { Type, useSession } from "@openmrs/esm-framework";
 import useGetSystemSetting from "../hooks/useGetSystemSetting";
 interface ParamTypes {
   formUuid?: string;
@@ -63,6 +63,7 @@ export const initialWorkflowState = {
     sessionNotes: null,
   },
   groupVisitTypeUuid: null,
+  userId: null,
 };
 
 const GroupFormWorkflowContext = React.createContext({
@@ -71,6 +72,7 @@ const GroupFormWorkflowContext = React.createContext({
 });
 
 const GroupFormWorkflowProvider = ({ children }) => {
+  const { user } = useSession();
   const { formUuid } = useParams() as ParamTypes;
   const activeFormUuid = formUuid.split("&")[0];
   const systemSetting = useGetSystemSetting(
@@ -88,6 +90,7 @@ const GroupFormWorkflowProvider = ({ children }) => {
         dispatch({
           type: "INITIALIZE_WORKFLOW_STATE",
           activeFormUuid,
+          userId: user.username,
         }),
       setGroup: (group) => dispatch({ type: "SET_GROUP", group }),
       unsetGroup: () => dispatch({ type: "UNSET_GROUP" }),
@@ -114,7 +117,7 @@ const GroupFormWorkflowProvider = ({ children }) => {
       destroySession: () => dispatch({ type: "DESTROY_SESSION" }),
       closeSession: () => dispatch({ type: "CLOSE_SESSION" }),
     }),
-    []
+    [user]
   );
 
   // if formUuid isn't a part of state yet, grab it from the url params

--- a/src/context/GroupFormWorkflowReducer.ts
+++ b/src/context/GroupFormWorkflowReducer.ts
@@ -4,8 +4,11 @@ import { initialWorkflowState } from "./FormWorkflowContext";
 export const fdeGroupWorkflowStorageVersion = "1.0.5";
 export const fdeGroupWorkflowStorageName =
   "openmrs:fastDataEntryGroupWorkflowState";
-const persistData = (data) => {
-  localStorage.setItem(fdeGroupWorkflowStorageName, JSON.stringify(data));
+const persistData = (data, userId) => {
+  localStorage.setItem(
+    fdeGroupWorkflowStorageName + ":" + userId,
+    JSON.stringify(data)
+  );
 };
 
 const initialFormState = {
@@ -24,7 +27,9 @@ const initialFormState = {
 const reducer = (state, action) => {
   switch (action.type) {
     case "INITIALIZE_WORKFLOW_STATE": {
-      const savedData = localStorage.getItem(fdeGroupWorkflowStorageName);
+      const savedData = localStorage.getItem(
+        fdeGroupWorkflowStorageName + ":" + action.userId
+      );
       const savedDataObject = savedData ? JSON.parse(savedData) : {};
       let newState: { [key: string]: unknown } = {};
       if (
@@ -69,7 +74,7 @@ const reducer = (state, action) => {
           activeFormUuid: action.activeFormUuid,
         };
       }
-      persistData(newState);
+      persistData(newState, action.userId);
       return newState;
     }
 
@@ -99,7 +104,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "UNSET_GROUP": {
@@ -119,7 +124,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "SET_SESSION_META": {
@@ -145,7 +150,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "ADD_PATIENT_UUID": {
@@ -170,7 +175,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "REMOVE_PATIENT_UUID": {
@@ -186,7 +191,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "SAVE_ENCOUNTER": {
@@ -198,7 +203,7 @@ const reducer = (state, action) => {
           forms: formRest,
           activeFormUuid: null,
         };
-        persistData(newState);
+        persistData(newState, state.userId);
         // eslint-disable-next-line
         navigate({ to: "${openmrsSpaBase}/forms" });
         return newState;
@@ -227,7 +232,7 @@ const reducer = (state, action) => {
             },
           },
         };
-        persistData(newState);
+        persistData(newState, state.userId);
         return newState;
       } else return state;
     }
@@ -247,7 +252,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "VALIDATE_FOR_NEXT":
@@ -389,7 +394,7 @@ const reducer = (state, action) => {
           },
         },
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       return newState;
     }
     case "DESTROY_SESSION": {
@@ -399,7 +404,7 @@ const reducer = (state, action) => {
         forms: formRest,
         activeFormUuid: null,
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       //eslint-disable-next-line
       navigate({ to: "${openmrsSpaBase}/forms" });
       return { ...newState, formDestroyed: true };
@@ -409,7 +414,7 @@ const reducer = (state, action) => {
         ...state,
         activeFormUuid: null,
       };
-      persistData(newState);
+      persistData(newState, state.userId);
       //eslint-disable-next-line
       navigate({ to: "${openmrsSpaBase}/forms" });
       return newState;

--- a/src/context/GroupFormWorkflowReducer.ts
+++ b/src/context/GroupFormWorkflowReducer.ts
@@ -72,6 +72,7 @@ const reducer = (state, action) => {
             [action.activeFormUuid]: initialFormState,
           },
           activeFormUuid: action.activeFormUuid,
+          userId: action.userId,
         };
       }
       persistData(newState, action.userId);

--- a/src/forms-page/FormsPage.tsx
+++ b/src/forms-page/FormsPage.tsx
@@ -1,4 +1,4 @@
-import { useConfig } from "@openmrs/esm-framework";
+import { useConfig, useSession } from "@openmrs/esm-framework";
 import { Tab, Tabs, TabList, TabPanels, TabPanel } from "@carbon/react";
 import React from "react";
 import { Config } from "../config-schema";
@@ -49,8 +49,13 @@ const FormsPage = () => {
   const { formCategories, formCategoriesToShow } = config;
   const { forms, isLoading, error } = useGetAllForms();
   const cleanRows = prepareRowsForTable(forms);
-  const savedFormsData = localStorage.getItem(fdeWorkflowStorageName);
-  const savedGroupFormsData = localStorage.getItem(fdeGroupWorkflowStorageName);
+  const { user } = useSession();
+  const savedFormsData = localStorage.getItem(
+    fdeWorkflowStorageName + ":" + user?.username
+  );
+  const savedGroupFormsData = localStorage.getItem(
+    fdeGroupWorkflowStorageName + ":" + user?.username
+  );
   const activeForms = [];
   const activeGroupForms = [];
 

--- a/src/forms-page/forms-table/FormsTable.tsx
+++ b/src/forms-page/forms-table/FormsTable.tsx
@@ -28,10 +28,11 @@ const FormsTable = ({
 }) => {
   const { t } = useTranslation();
 
-  const formsHeader = [
+  const tableHeaders = [
     {
       key: "display",
       header: t("formName", "Form Name"),
+      isSortable: true,
     },
     {
       key: "actions",
@@ -43,7 +44,7 @@ const FormsTable = ({
     },
   ];
 
-  const augmenteRows = rows?.map((row) => ({
+  const augmentedRows = rows?.map((row) => ({
     ...row,
     actions: (
       <Link to={`form/${row.uuid}`}>
@@ -70,7 +71,7 @@ const FormsTable = ({
       />
     );
   }
-  if (augmenteRows.length === 0) {
+  if (augmentedRows.length === 0) {
     return (
       <EmptyState
         headerTitle={t("noFormsFound", "No Forms To Show")}
@@ -82,7 +83,7 @@ const FormsTable = ({
     );
   }
   return (
-    <DataTable rows={augmenteRows} headers={formsHeader} isSortable>
+    <DataTable rows={augmentedRows} headers={tableHeaders}>
       {({
         rows,
         headers,
@@ -104,7 +105,12 @@ const FormsTable = ({
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (
-                    <TableHeader {...getHeaderProps({ header })}>
+                    <TableHeader
+                      {...getHeaderProps({
+                        header,
+                        isSortable: header.isSortable,
+                      })}
+                    >
                       {header.header}
                     </TableHeader>
                   ))}

--- a/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
+++ b/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
@@ -92,11 +92,7 @@ const GroupSessionWorkspace = () => {
     submitForComplete,
   } = useContext(GroupFormWorkflowContext);
 
-  const {
-    saveVisit,
-    success: visitSaveSuccess,
-    isSubmitting,
-  } = useStartVisit({
+  const { saveVisit, success: visitSaveSuccess } = useStartVisit({
     showSuccessNotification: false,
     showErrorNotification: true,
   });
@@ -132,7 +128,6 @@ const GroupSessionWorkspace = () => {
       saveVisit,
       activeVisitUuid,
       submitForNext,
-      isSubmitting,
     ]
   );
 

--- a/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
+++ b/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
@@ -92,7 +92,11 @@ const GroupSessionWorkspace = () => {
     submitForComplete,
   } = useContext(GroupFormWorkflowContext);
 
-  const { saveVisit, success: visitSaveSuccess } = useStartVisit({
+  const {
+    saveVisit,
+    success: visitSaveSuccess,
+    isSubmitting,
+  } = useStartVisit({
     showSuccessNotification: false,
     showErrorNotification: true,
   });
@@ -128,6 +132,7 @@ const GroupSessionWorkspace = () => {
       saveVisit,
       activeVisitUuid,
       submitForNext,
+      isSubmitting,
     ]
   );
 

--- a/src/hooks/useStartVisit.ts
+++ b/src/hooks/useStartVisit.ts
@@ -59,7 +59,7 @@ const useStartVisit = ({
         startDatetime: data.startDatetime,
         stopDatetime: data.stopDatetime,
         visitType: data.visitType,
-        // location: selectedLocation,
+        location: data.location,
       };
       openmrsFetch("/ws/rest/v1/visit", {
         method: "POST",
@@ -72,8 +72,17 @@ const useStartVisit = ({
     [onError, onSave]
   );
 
+  const updateEncounter = useCallback((data) => {
+    openmrsFetch("/ws/rest/v1/encounter/" + data.uuid, {
+      method: "POST",
+      body: { visit: data.visit },
+      headers: { "Content-Type": "application/json" },
+    });
+  }, []);
+
   return {
     saveVisit,
+    updateEncounter,
     success,
     error,
     isSubmitting,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Workflow was being saved on browser localStorage independently of the logged user meaning that, if a user logged out and another user logged in using the same browser, the workflow from 1st user would be loaded and overwritten.
With this PR, the workflow is saved on localStorage having the userId as a suffix so that workflow is properly loaded/saved per user.
