### PR TITLE
(fix) Only Form Name row should be sortable

### DIFF
--- a/src/forms-page/forms-table/FormsTable.tsx
+++ b/src/forms-page/forms-table/FormsTable.tsx
@@ -28,10 +28,11 @@ const FormsTable = ({
 }) => {
   const { t } = useTranslation();
 
-  const formsHeader = [
+  const tableHeaders = [
     {
       key: "display",
       header: t("formName", "Form Name"),
+      isSortable: true,
     },
     {
       key: "actions",
@@ -43,7 +44,7 @@ const FormsTable = ({
     },
   ];
 
-  const augmenteRows = rows?.map((row) => ({
+  const augmentedRows = rows?.map((row) => ({
     ...row,
     actions: (
       <Link to={`form/${row.uuid}`}>
@@ -70,7 +71,7 @@ const FormsTable = ({
       />
     );
   }
-  if (augmenteRows.length === 0) {
+  if (augmentedRows.length === 0) {
     return (
       <EmptyState
         headerTitle={t("noFormsFound", "No Forms To Show")}
@@ -82,7 +83,7 @@ const FormsTable = ({
     );
   }
   return (
-    <DataTable rows={augmenteRows} headers={formsHeader} isSortable>
+    <DataTable rows={augmentedRows} headers={tableHeaders}>
       {({
         rows,
         headers,
@@ -104,7 +105,12 @@ const FormsTable = ({
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (
-                    <TableHeader {...getHeaderProps({ header })}>
+                    <TableHeader
+                      {...getHeaderProps({
+                        header,
+                        isSortable: header.isSortable,
+                      })}
+                    >
                       {header.header}
                     </TableHeader>
                   ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Sets up the DataTable table headers such that only the Form Name row is sortable. The Actions row doesn't benefit from being sortable because of the kind of content it contains. Also renames a couple of variables.

## Screenshots

> Before

<img width="1403" alt="Screenshot 2023-01-13 at 22 36 28" src="https://user-images.githubusercontent.com/8509731/212404651-641ecffb-f220-4dc7-9d2e-702d7434d962.png">

> After
<img width="1098" alt="Screenshot 2023-01-13 at 22 26 07" src="https://user-images.githubusercontent.com/8509731/212402681-6c546146-8ff1-4e50-b4c7-dcdccd733ec5.png">
