### PR TITLE
(feat) Save and load distinct workflows per logged user

### DIFF
--- a/src/context/FormWorkflowContext.tsx
+++ b/src/context/FormWorkflowContext.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useReducer } from "react";
 import reducer from "./FormWorkflowReducer";
 import { useParams, useLocation } from "react-router-dom";
 import useGetSystemSetting from "../hooks/useGetSystemSetting";
+import { useSession } from "@openmrs/esm-framework";
 interface ParamTypes {
   formUuid?: string;
 }
@@ -32,6 +33,7 @@ export const initialWorkflowState = {
   patientUuids: [], // pseudo field from state[activeFormUuid].patientUuids
   encounters: {}, // pseudo field from state[activeFormUuid].encounters
   singleSessionVisitTypeUuid: null,
+  userUuid: null, // UUID of the user to which this workflow state belongs to
 };
 
 const FormWorkflowContext = React.createContext({
@@ -40,6 +42,7 @@ const FormWorkflowContext = React.createContext({
 });
 
 const FormWorkflowProvider = ({ children }) => {
+  const { user } = useSession();
   const { formUuid } = useParams() as ParamTypes;
   const activeFormUuid = formUuid.split("&")[0];
   const { search } = useLocation();
@@ -61,6 +64,7 @@ const FormWorkflowProvider = ({ children }) => {
           type: "INITIALIZE_WORKFLOW_STATE",
           activeFormUuid,
           newPatientUuid,
+          userUuid: user.uuid,
         }),
       addPatient: (patientUuid) =>
         dispatch({ type: "ADD_PATIENT", patientUuid }),
@@ -79,7 +83,7 @@ const FormWorkflowProvider = ({ children }) => {
       destroySession: () => dispatch({ type: "DESTROY_SESSION" }),
       closeSession: () => dispatch({ type: "CLOSE_SESSION" }),
     }),
-    []
+    [user]
   );
 
   // if formUuid isn't a part of state yet, grab it from the url params

--- a/src/context/FormWorkflowReducer.ts
+++ b/src/context/FormWorkflowReducer.ts
@@ -1,7 +1,7 @@
 import { navigate } from "@openmrs/esm-framework";
 import { initialWorkflowState } from "./FormWorkflowContext";
 
-export const fdeWorkflowStorageVersion = "1.1.13";
+export const fdeWorkflowStorageVersion = "1.1.0";
 export const fdeWorkflowStorageName = "openmrs:fastDataEntryWorkflowState";
 const persistData = (data) => {
   localStorage.setItem(

--- a/src/context/FormWorkflowReducer.ts
+++ b/src/context/FormWorkflowReducer.ts
@@ -1,10 +1,13 @@
 import { navigate } from "@openmrs/esm-framework";
 import { initialWorkflowState } from "./FormWorkflowContext";
 
-export const fdeWorkflowStorageVersion = "1.0.13";
+export const fdeWorkflowStorageVersion = "1.1.13";
 export const fdeWorkflowStorageName = "openmrs:fastDataEntryWorkflowState";
 const persistData = (data) => {
-  localStorage.setItem(fdeWorkflowStorageName, JSON.stringify(data));
+  localStorage.setItem(
+    fdeWorkflowStorageName + ":" + data.userUuid,
+    JSON.stringify(data)
+  );
 };
 
 const initialFormState = {
@@ -18,7 +21,9 @@ const initialFormState = {
 const reducer = (state, action) => {
   switch (action.type) {
     case "INITIALIZE_WORKFLOW_STATE": {
-      const savedData = localStorage.getItem(fdeWorkflowStorageName);
+      const savedData = localStorage.getItem(
+        fdeWorkflowStorageName + ":" + action.userUuid
+      );
       const savedDataObject = savedData ? JSON.parse(savedData) : {};
       let newState: { [key: string]: unknown } = {};
       const newPatient = action.newPatientUuid
@@ -69,6 +74,7 @@ const reducer = (state, action) => {
             [action.activeFormUuid]: initialFormState,
           },
           activeFormUuid: action.activeFormUuid,
+          userUuid: action.userUuid,
         };
       }
       persistData(newState);

--- a/src/context/GroupFormWorkflowContext.tsx
+++ b/src/context/GroupFormWorkflowContext.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useReducer } from "react";
 import reducer from "./GroupFormWorkflowReducer";
 import { useParams } from "react-router-dom";
-import { Type } from "@openmrs/esm-framework";
+import { Type, useSession } from "@openmrs/esm-framework";
 import useGetSystemSetting from "../hooks/useGetSystemSetting";
 interface ParamTypes {
   formUuid?: string;
@@ -63,6 +63,7 @@ export const initialWorkflowState = {
     sessionNotes: null,
   },
   groupVisitTypeUuid: null,
+  userUuid: null, // UUID of the user to which this workflow state belongs to
 };
 
 const GroupFormWorkflowContext = React.createContext({
@@ -71,6 +72,7 @@ const GroupFormWorkflowContext = React.createContext({
 });
 
 const GroupFormWorkflowProvider = ({ children }) => {
+  const { user } = useSession();
   const { formUuid } = useParams() as ParamTypes;
   const activeFormUuid = formUuid.split("&")[0];
   const systemSetting = useGetSystemSetting(
@@ -88,6 +90,7 @@ const GroupFormWorkflowProvider = ({ children }) => {
         dispatch({
           type: "INITIALIZE_WORKFLOW_STATE",
           activeFormUuid,
+          userUuid: user.uuid,
         }),
       setGroup: (group) => dispatch({ type: "SET_GROUP", group }),
       unsetGroup: () => dispatch({ type: "UNSET_GROUP" }),
@@ -115,7 +118,7 @@ const GroupFormWorkflowProvider = ({ children }) => {
       destroySession: () => dispatch({ type: "DESTROY_SESSION" }),
       closeSession: () => dispatch({ type: "CLOSE_SESSION" }),
     }),
-    []
+    [user]
   );
 
   // if formUuid isn't a part of state yet, grab it from the url params

--- a/src/context/GroupFormWorkflowReducer.ts
+++ b/src/context/GroupFormWorkflowReducer.ts
@@ -5,7 +5,10 @@ export const fdeGroupWorkflowStorageVersion = "1.0.5";
 export const fdeGroupWorkflowStorageName =
   "openmrs:fastDataEntryGroupWorkflowState";
 const persistData = (data) => {
-  localStorage.setItem(fdeGroupWorkflowStorageName, JSON.stringify(data));
+  localStorage.setItem(
+    fdeGroupWorkflowStorageName + ":" + data.userUuid,
+    JSON.stringify(data)
+  );
 };
 
 const initialFormState = {
@@ -24,7 +27,9 @@ const initialFormState = {
 const reducer = (state, action) => {
   switch (action.type) {
     case "INITIALIZE_WORKFLOW_STATE": {
-      const savedData = localStorage.getItem(fdeGroupWorkflowStorageName);
+      const savedData = localStorage.getItem(
+        fdeGroupWorkflowStorageName + ":" + action.userUuid
+      );
       const savedDataObject = savedData ? JSON.parse(savedData) : {};
       let newState: { [key: string]: unknown } = {};
       if (
@@ -67,6 +72,7 @@ const reducer = (state, action) => {
             [action.activeFormUuid]: initialFormState,
           },
           activeFormUuid: action.activeFormUuid,
+          userUuid: action.userUuid,
         };
       }
       persistData(newState);

--- a/src/forms-page/FormsPage.tsx
+++ b/src/forms-page/FormsPage.tsx
@@ -1,4 +1,4 @@
-import { useConfig } from "@openmrs/esm-framework";
+import { useConfig, useSession } from "@openmrs/esm-framework";
 import { Tab, Tabs, TabList, TabPanels, TabPanel } from "@carbon/react";
 import React from "react";
 import { Config } from "../config-schema";
@@ -49,8 +49,13 @@ const FormsPage = () => {
   const { formCategories, formCategoriesToShow } = config;
   const { forms, isLoading, error } = useGetAllForms();
   const cleanRows = prepareRowsForTable(forms);
-  const savedFormsData = localStorage.getItem(fdeWorkflowStorageName);
-  const savedGroupFormsData = localStorage.getItem(fdeGroupWorkflowStorageName);
+  const { user } = useSession();
+  const savedFormsData = localStorage.getItem(
+    fdeWorkflowStorageName + ":" + user?.uuid
+  );
+  const savedGroupFormsData = localStorage.getItem(
+    fdeGroupWorkflowStorageName + ":" + user?.uuid
+  );
   const activeForms = [];
   const activeGroupForms = [];
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Workflow was being saved on browser localStorage independently of the logged user meaning that, if a user logged out and another user logged in using the same browser, the workflow from 1st user would be loaded and overwritten.
With this PR, the workflow is saved on localStorage having the userId as a suffix so that workflow is properly loaded/saved per user.