### PR TITLE
(feat) Groups Session Visit

### DIFF
--- a/src/context/GroupFormWorkflowContext.tsx
+++ b/src/context/GroupFormWorkflowContext.tsx
@@ -29,7 +29,7 @@ const initialActions = {
   validateForNext: () => undefined,
   validateForComplete: () => undefined,
   updateVisitUuid: (visitUuid: string) => undefined,
-  submitForNext: () => undefined,
+  submitForNext: (nextPatientUuid: string = null) => undefined,
   submitForReview: () => undefined,
   submitForComplete: () => undefined,
   addPatientUuid: (patientUuid: string) => undefined,
@@ -106,7 +106,8 @@ const GroupFormWorkflowProvider = ({ children }) => {
       validateForComplete: () => dispatch({ type: "VALIDATE_FOR_COMPLETE" }),
       updateVisitUuid: (visitUuid) =>
         dispatch({ type: "UPDATE_VISIT_UUID", visitUuid }),
-      submitForNext: () => dispatch({ type: "SUBMIT_FOR_NEXT" }),
+      submitForNext: (nextPatientUuid) =>
+        dispatch({ type: "SUBMIT_FOR_NEXT", nextPatientUuid }),
       submitForComplete: () => dispatch({ type: "SUBMIT_FOR_COMPLETE" }),
       editEncounter: (patientUuid) =>
         dispatch({ type: "EDIT_ENCOUNTER", patientUuid }),

--- a/src/context/GroupFormWorkflowReducer.ts
+++ b/src/context/GroupFormWorkflowReducer.ts
@@ -203,13 +203,14 @@ const reducer = (state, action) => {
         navigate({ to: "${openmrsSpaBase}/forms" });
         return newState;
       } else if (thisForm.workflowState === "SUBMIT_FOR_NEXT") {
-        const nextPatientUuid =
-          thisForm.patientUuids[
-            Math.min(
-              thisForm.patientUuids.indexOf(thisForm.activePatientUuid) + 1,
-              thisForm.patientUuids.length - 1
-            )
-          ];
+        const nextPatientUuid = state.nextPatientUuid
+          ? state.nextPatientUuid
+          : thisForm.patientUuids[
+              Math.min(
+                thisForm.patientUuids.indexOf(thisForm.activePatientUuid) + 1,
+                thisForm.patientUuids.length - 1
+              )
+            ];
         const newState = {
           ...state,
           forms: {
@@ -310,6 +311,7 @@ const reducer = (state, action) => {
             workflowState: "SUBMIT_FOR_NEXT",
           },
         },
+        nextPatientUuid: action.nextPatientUuid,
       };
     case "SUBMIT_FOR_REVIEW":
       // this state should not be persisted

--- a/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
+++ b/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
@@ -1,4 +1,9 @@
-import { getGlobalStore, useConfig, useStore } from "@openmrs/esm-framework";
+import {
+  getGlobalStore,
+  useConfig,
+  useSession,
+  useStore,
+} from "@openmrs/esm-framework";
 import { Button } from "@carbon/react";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import PatientCard from "../patient-card/PatientCard";
@@ -17,6 +22,7 @@ const WorkflowNavigationButtons = () => {
   const {
     activeFormUuid,
     validateForNext,
+    submitForNext,
     patientUuids,
     activePatientUuid,
     workflowState,
@@ -34,7 +40,7 @@ const WorkflowNavigationButtons = () => {
 
   const handleClickNext = () => {
     if (workflowState === "EDIT_FORM") {
-      validateForNext();
+      submitForNext();
     }
   };
 
@@ -66,7 +72,7 @@ const WorkflowNavigationButtons = () => {
         open={completeModalOpen}
         setOpen={setCompleteModalOpen}
         context={context}
-        validateFirst={true}
+        validateFirst={false}
       />
     </>
   );
@@ -92,74 +98,56 @@ const GroupSessionWorkspace = () => {
     submitForComplete,
   } = useContext(GroupFormWorkflowContext);
 
-  const { saveVisit, success: visitSaveSuccess } = useStartVisit({
+  const { user, sessionLocation } = useSession();
+  const [encounter, setEncounter] = useState(null);
+  const [visit, setVisit] = useState(null);
+
+  const {
+    saveVisit,
+    updateEncounter,
+    success: visitSaveSuccess,
+  } = useStartVisit({
     showSuccessNotification: false,
     showErrorNotification: true,
   });
 
   // 0. user clicks "next patient" in WorkflowNavigationButtons
-  // which triggers validateForNext() if workflowState === "EDIT_FORM"
+  // which triggers submitForNext() if workflowState === "EDIT_FORM"
 
-  // 1. validate the form
-  // if the form is valid, save a visit for the user
-  // handleOnValidate is a callback passed to the form engine.
-  const handleOnValidate = useCallback(
-    (valid) => {
-      if (valid && !activeVisitUuid) {
-        // make a visit
-        // we will not persist this state or update the reducer
-        const date = new Date(activeSessionMeta.sessionDate);
-        date.setHours(date.getHours() + 1);
-        saveVisit({
-          patientUuid: activePatientUuid,
-          startDatetime: activeSessionMeta.sessionDate,
-          stopDatetime: date.toISOString(),
-          visitType: groupVisitTypeUuid,
-        });
-      } else if (valid && activeVisitUuid) {
-        // there is already a visit for this form
-        submitForNext();
-      }
-    },
-    [
-      activePatientUuid,
-      activeSessionMeta,
-      groupVisitTypeUuid,
-      saveVisit,
-      activeVisitUuid,
-      submitForNext,
-    ]
-  );
-
-  // 2. save the new visit uuid and start form submission
+  // 1. save the new visit uuid and start form submission
   useEffect(() => {
-    if (visitSaveSuccess) {
-      const visitUuid = visitSaveSuccess?.data?.uuid;
-      if (!activeVisitUuid) {
-        updateVisitUuid(visitUuid);
-      }
-      if (workflowState === "VALIDATE_FOR_NEXT") {
-        submitForNext();
-      }
-      if (workflowState === "VALIDATE_FOR_COMPLETE") {
-        submitForComplete();
-      }
+    if (
+      visitSaveSuccess &&
+      visitSaveSuccess.data.patient.uuid === activePatientUuid
+    ) {
+      setVisit(visitSaveSuccess.data);
+      const visitUuid = visitSaveSuccess.data.uuid;
+      // Update visit UUID on workflow
+      updateVisitUuid(visitSaveSuccess.data.uuid);
     }
   }, [
     visitSaveSuccess,
     updateVisitUuid,
-    submitForNext,
-    workflowState,
     activeVisitUuid,
-    submitForComplete,
+    activePatientUuid,
+    visit,
+    setVisit,
   ]);
 
-  // 3. on form payload creation inject the activeVisitUuid
+  // 2. If there's no active visit, trigger the creation of a new one
   const handleEncounterCreate = useCallback(
     (payload) => {
+      // Create a visit with the same date as the encounter being saved
+      if (!activeVisitUuid) {
+        saveVisit({
+          patientUuid: activePatientUuid,
+          startDatetime: activeSessionMeta.sessionDate,
+          stopDatetime: activeSessionMeta.sessionDate,
+          visitType: groupVisitTypeUuid,
+          location: sessionLocation?.uuid,
+        });
+      }
       const obsTime = new Date(activeSessionMeta.sessionDate);
-      obsTime.setMinutes(obsTime.getMinutes() + 1);
-
       payload.obs.forEach((item, index) => {
         payload.obs[index] = {
           ...item,
@@ -170,21 +158,49 @@ const GroupSessionWorkspace = () => {
           obsDatetime: obsTime.toISOString(),
         };
       });
-      Object.entries(groupSessionConcepts).forEach(([field, uuid]) => {
-        payload.obs.push({ concept: uuid, value: activeSessionMeta?.[field] });
-      });
-      payload.visit = activeVisitUuid;
+      // If this is a newly created encounter and visit, add session concepts to encounter payload.
+      if (!activeVisitUuid) {
+        Object.entries(groupSessionConcepts).forEach(([field, uuid]) => {
+          payload.obs.push({
+            concept: uuid,
+            value: activeSessionMeta?.[field],
+          });
+        });
+      }
+      payload.location = sessionLocation?.uuid;
       payload.encounterDatetime = obsTime.toISOString();
     },
-    [activeVisitUuid, activeSessionMeta, groupSessionConcepts]
+    [
+      activePatientUuid,
+      activeVisitUuid,
+      activeSessionMeta,
+      groupSessionConcepts,
+      groupVisitTypeUuid,
+      encounter,
+    ]
   );
+
+  // 3. Update encounter so that it belongs to the created visit
+  useEffect(() => {
+    if (encounter && visit) {
+      updateEncounter({ uuid: encounter.uuid, visit: visit.uuid });
+    }
+  }, [encounter, visit]);
 
   // 4. Once form has been posted, save the new encounter uuid so we can edit it later
   const handlePostResponse = useCallback(
     (encounter) => {
       if (encounter && encounter.uuid) {
         saveEncounter(encounter.uuid);
+        setEncounter(encounter);
       }
+    },
+    [saveEncounter]
+  );
+
+  const switchPatient = useCallback(
+    (patientUuid) => {
+      submitForNext(patientUuid);
     },
     [saveEncounter]
   );
@@ -201,7 +217,6 @@ const GroupSessionWorkspace = () => {
             {...{
               formUuid: activeFormUuid,
               handlePostResponse,
-              handleOnValidate,
               handleEncounterCreate,
             }}
           />
@@ -215,7 +230,7 @@ const GroupSessionWorkspace = () => {
                 {...{
                   patientUuid,
                   activePatientUuid,
-                  editEncounter,
+                  editEncounter: switchPatient,
                   encounters,
                 }}
               />

--- a/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
+++ b/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
@@ -21,7 +21,6 @@ const WorkflowNavigationButtons = () => {
   const context = useContext(GroupFormWorkflowContext);
   const {
     activeFormUuid,
-    validateForNext,
     submitForNext,
     patientUuids,
     activePatientUuid,
@@ -84,7 +83,6 @@ const GroupSessionWorkspace = () => {
   const {
     patientUuids,
     activePatientUuid,
-    editEncounter,
     encounters,
     activeEncounterUuid,
     activeVisitUuid,
@@ -95,10 +93,9 @@ const GroupSessionWorkspace = () => {
     updateVisitUuid,
     submitForNext,
     workflowState,
-    submitForComplete,
   } = useContext(GroupFormWorkflowContext);
 
-  const { user, sessionLocation } = useSession();
+  const { sessionLocation } = useSession();
   const [encounter, setEncounter] = useState(null);
   const [visit, setVisit] = useState(null);
 
@@ -121,7 +118,6 @@ const GroupSessionWorkspace = () => {
       visitSaveSuccess.data.patient.uuid === activePatientUuid
     ) {
       setVisit(visitSaveSuccess.data);
-      const visitUuid = visitSaveSuccess.data.uuid;
       // Update visit UUID on workflow
       updateVisitUuid(visitSaveSuccess.data.uuid);
     }
@@ -176,7 +172,8 @@ const GroupSessionWorkspace = () => {
       activeSessionMeta,
       groupSessionConcepts,
       groupVisitTypeUuid,
-      encounter,
+      saveVisit,
+      sessionLocation,
     ]
   );
 
@@ -185,7 +182,7 @@ const GroupSessionWorkspace = () => {
     if (encounter && visit) {
       updateEncounter({ uuid: encounter.uuid, visit: visit.uuid });
     }
-  }, [encounter, visit]);
+  }, [encounter, updateEncounter, visit]);
 
   // 4. Once form has been posted, save the new encounter uuid so we can edit it later
   const handlePostResponse = useCallback(
@@ -202,7 +199,7 @@ const GroupSessionWorkspace = () => {
     (patientUuid) => {
       submitForNext(patientUuid);
     },
-    [saveEncounter]
+    [submitForNext]
   );
 
   if (workflowState === "NEW_GROUP_SESSION") return null;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
On a group session, each patient encounter is now created wrapped in each own visit (one distinct visit per patient). Flow and outcome is the same as it was implemented for individual session (https://github.com/openmrs/openmrs-esm-fast-data-entry-app/pull/43):

1. The encounter is 1st created detached from any visit (same as before)
2. On the handleEncounterCreate callback, a visit creation with the same date is triggered
3. Because the visit was created async, after creation, the encounter is then updated so that it belongs to the visit

When a session is in progress, the user will be able two switch between the forms for the patients belonging to the group. When the form is saved the 1st time, a visit is created to wrap the encounter (flow above). When the user return to an already saved form to edit it, already existing encounter and visit will be updated.