### PR TITLE
(fix) Trigger formentry slot refresh

### DIFF
--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { detach, ExtensionSlot } from "@openmrs/esm-framework";
 import useGetPatient from "./hooks/useGetPatient";
 
@@ -126,9 +126,20 @@ const FormBootstrap = ({
     return () => detach("form-widget-slot", "form-widget-slot");
   });
 
+  const [showForm, setShowForm] = useState(true);
+
+  useEffect(() => {
+    if (patientUuid) {
+      setShowForm(false);
+      setTimeout(() => {
+        setShowForm(true);
+      });
+    }
+  }, [patientUuid]);
+
   return (
     <div>
-      {formUuid && patientUuid && patient && (
+      {showForm && formUuid && patientUuid && patient && (
         <ExtensionSlot
           name="form-widget-slot"
           state={{

--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -126,6 +126,7 @@ const FormBootstrap = ({
     return () => detach("form-widget-slot", "form-widget-slot");
   });
 
+  // FIXME This should not be necessary
   const [showForm, setShowForm] = useState(true);
 
   useEffect(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Form rendered within the extension slot using openmrs-ngx-formentry wasn't properly updating after the patient was changed unless a manual browse refresh was triggered. With this fix, when the patient is changed, the slot containing the form is forced to be refreshed.