### PR TITLE
(refactor) Replace usages of /ws/rest/v1 with restBaseUrl

### DIFF
--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,9 +1,13 @@
-import { type FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import {
+  type FetchResponse,
+  openmrsFetch,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 import useSWR from "swr";
 import { SpecificQuestion, SpecificQuestionConfig } from "../types";
 import { useMemo } from "react";
 
-const formUrl = "/ws/rest/v1/o3/forms";
+const formUrl = `${restBaseUrl}/o3/forms`;
 
 export const useSpecificQuestions = (
   formUuid: string,

--- a/src/hooks/useGetAllForms.ts
+++ b/src/hooks/useGetAllForms.ts
@@ -2,14 +2,15 @@ import {
   openmrsFetch,
   userHasAccess,
   useSession,
+  restBaseUrl,
 } from "@openmrs/esm-framework";
 import useSWR from "swr";
 
 const customFormRepresentation =
   "(uuid,name,display,encounterType:(uuid,name,viewPrivilege,editPrivilege),version,published,retired,resources:(uuid,name,dataType,valueReference))";
 
-const formEncounterUrl = `/ws/rest/v1/form?v=custom:${customFormRepresentation}`;
-const formEncounterUrlPoc = `/ws/rest/v1/form?v=custom:${customFormRepresentation}&q=poc`;
+const formEncounterUrl = `${restBaseUrl}/form?v=custom:${customFormRepresentation}`;
+const formEncounterUrlPoc = `${restBaseUrl}/form?v=custom:${customFormRepresentation}&q=poc`;
 
 export function useGetAllForms(cachedOfflineFormsOnly = false) {
   const session = useSession();

--- a/src/hooks/useGetEncounter.ts
+++ b/src/hooks/useGetEncounter.ts
@@ -1,7 +1,7 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 import useSWR from "swr";
 
-const encounterUrl = "/ws/rest/v1/encounter/";
+const encounterUrl = `${restBaseUrl}/encounter/`;
 
 const useGetEncounter = (encounterUuid) => {
   const url = `${encounterUrl}${encounterUuid}`;

--- a/src/hooks/useGetSystemSetting.ts
+++ b/src/hooks/useGetSystemSetting.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 
 const useGetSystemSetting = (settingId) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -19,7 +19,7 @@ const useGetSystemSetting = (settingId) => {
   }, []);
 
   const getSetting = useCallback(() => {
-    openmrsFetch(`/ws/rest/v1/systemsetting?q=${settingId}&v=default`)
+    openmrsFetch(`${restBaseUrl}/systemsetting?q=${settingId}&v=default`)
       .then(onResult)
       .catch(onError);
   }, [onError, onResult, settingId]);

--- a/src/hooks/usePostEndpoint.ts
+++ b/src/hooks/usePostEndpoint.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 import { useCallback, useState } from "react";
 
 const usePostEndpoint = ({ endpointUrl }) => {
@@ -66,11 +66,11 @@ const usePostEndpoint = ({ endpointUrl }) => {
 };
 
 const usePostVisit = () => {
-  return usePostEndpoint({ endpointUrl: "/ws/rest/v1/visit" });
+  return usePostEndpoint({ endpointUrl: `${restBaseUrl}/visit` });
 };
 
 const usePostCohort = () => {
-  return usePostEndpoint({ endpointUrl: "/ws/rest/v1/cohortm/cohort" });
+  return usePostEndpoint({ endpointUrl: `${restBaseUrl}/cohortm/cohort` });
 };
 
 export { usePostEndpoint, usePostVisit, usePostCohort };

--- a/src/hooks/useSearchEndpoint.ts
+++ b/src/hooks/useSearchEndpoint.ts
@@ -1,4 +1,8 @@
-import { openmrsFetch, FetchResponse } from "@openmrs/esm-framework";
+import {
+  openmrsFetch,
+  FetchResponse,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 import { useCallback, useMemo } from "react";
 import useSWRInfinite from "swr/infinite";
 
@@ -111,7 +115,7 @@ const useSearchCohortInfinite = ({
   ...props
 }: SearchInfiniteProps): SearchResponse => {
   return useSearchEndpointInfinite({
-    baseUrl: "/ws/rest/v1/cohortm/cohort",
+    baseUrl: `${restBaseUrl}/cohortm/cohort`,
     resultsToFetch: 10,
     ...props,
   });

--- a/src/hooks/useStartVisit.ts
+++ b/src/hooks/useStartVisit.ts
@@ -4,6 +4,7 @@ import {
   showNotification,
   showToast,
   openmrsFetch,
+  restBaseUrl,
 } from "@openmrs/esm-framework";
 
 const useStartVisit = ({
@@ -61,7 +62,7 @@ const useStartVisit = ({
         visitType: data.visitType,
         location: data.location,
       };
-      openmrsFetch("/ws/rest/v1/visit", {
+      openmrsFetch(`${restBaseUrl}/visit`, {
         method: "POST",
         body: payload,
         headers: { "Content-Type": "application/json" },
@@ -73,7 +74,7 @@ const useStartVisit = ({
   );
 
   const updateEncounter = useCallback((data) => {
-    openmrsFetch("/ws/rest/v1/encounter/" + data.uuid, {
+    openmrsFetch(`${restBaseUrl}/encounter/` + data.uuid, {
       method: "POST",
       body: { visit: data.visit },
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Change all instances of the hard-coded API base URL '/ws/rest/v1/' to use the restBaseUrl variable instead. To enhances maintainability and flexibility of the API base URL configuration.

## Screenshots
N/A

## Related Issue
https://openmrs.atlassian.net/browse/O3-2815

## Other
<!-- Anything not covered above -->
