### PR TITLE
Fixed last patient form duplication

### DIFF
--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -137,14 +137,12 @@ const FormBootstrap = ({
   // FIXME This should not be necessary
   const [showForm, setShowForm] = useState(true);
 
-  useEffect(() => {
-    if (patientUuid && formUuid && patient) {
-      setShowForm(false);
-      setTimeout(() => {
-        setShowForm(true);
-      });
-    }
-  }, [patientUuid, formUuid, patient]);
+  const updateFormComponent = () => {
+    setShowForm(false);
+    setTimeout(() => {
+      setShowForm(true);
+    });
+  };
 
   return (
     <div>
@@ -160,7 +158,10 @@ const FormBootstrap = ({
             patient,
             encounterUuid: encounterUuid ?? "",
             closeWorkspace: () => undefined,
-            handlePostResponse,
+            handlePostResponse: (encounter) => {
+              handlePostResponse(encounter);
+              updateFormComponent();
+            },
             handleEncounterCreate,
             handleOnValidate,
             showDiscardSubmitButtons: false,

--- a/src/context/GroupFormWorkflowReducer.ts
+++ b/src/context/GroupFormWorkflowReducer.ts
@@ -234,7 +234,7 @@ const reducer = (state, action) => {
             ...state.forms,
             [state.activeFormUuid]: {
               ...thisForm,
-              encounters: encounters,
+              encounters,
               activePatientUuid: nextPatientUuid,
               activeEncounterUuid: encounters[nextPatientUuid] || null,
               activeVisitUuid: thisForm.visits[nextPatientUuid] || null,

--- a/src/context/GroupFormWorkflowReducer.ts
+++ b/src/context/GroupFormWorkflowReducer.ts
@@ -217,18 +217,19 @@ const reducer = (state, action) => {
                 thisForm.patientUuids.length - 1
               )
             ];
+        const encounters = {
+          ...thisForm.encounters,
+          [thisForm.activePatientUuid]: action.encounterUuid,
+        };
         const newState = {
           ...state,
           forms: {
             ...state.forms,
             [state.activeFormUuid]: {
               ...thisForm,
-              encounters: {
-                ...thisForm.encounters,
-                [thisForm.activePatientUuid]: action.encounterUuid,
-              },
+              encounters: encounters,
               activePatientUuid: nextPatientUuid,
-              activeEncounterUuid: thisForm.encounters[nextPatientUuid] || null,
+              activeEncounterUuid: encounters[nextPatientUuid] || null,
               activeVisitUuid: thisForm.visits[nextPatientUuid] || null,
               workflowState: "EDIT_FORM",
             },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR solves the problem of form duplication on fast data entry:
Steps to replicate:
1. After creating your session move to the last Patient.
![image](https://github.com/openmrs/openmrs-esm-fast-data-entry-app/assets/68058940/3449faaa-c7fb-493e-a30a-7d219e29cc49)
3. Press the button "Save form". (The form will not appear)
![image](https://github.com/openmrs/openmrs-esm-fast-data-entry-app/assets/68058940/00140c78-84e5-4df1-aa7b-0970c36e0f99)
5. then press the button "Save & Complete".
![image](https://github.com/openmrs/openmrs-esm-fast-data-entry-app/assets/68058940/1c0ed9e8-f65f-4053-a621-97e78b403b7a)
7. The last patient form will be duplicated.
![image](https://github.com/openmrs/openmrs-esm-fast-data-entry-app/assets/68058940/616fd82f-90b8-4ce4-9e2e-91a9252acae9)

