### PR TITLE
(feat) Support for static specific answers

### DIFF
--- a/src/hooks/useSpecificQuestions.ts
+++ b/src/hooks/useSpecificQuestions.ts
@@ -48,6 +48,16 @@ function getQuestions(specificQuestions: Array<SpecificQuestionConfig>, formSche
         .map((question) => {
           const specificQuestion = specificQuestionsMap.get(question.id) || {};
 
+          const answers =
+            (specificQuestion as SpecificQuestionConfig).answers?.map((a) => ({
+              value: a,
+              display: conceptLabels[a]?.display,
+            })) ||
+            (question.questionOptions.answers ?? []).map((answer) => ({
+              value: answer.concept,
+              display: answer.label ?? conceptLabels[answer.concept]?.display,
+            }));
+
           return {
             question: {
               display: question.label ?? conceptLabels[question.questionOptions.concept]?.display,
@@ -55,10 +65,7 @@ function getQuestions(specificQuestions: Array<SpecificQuestionConfig>, formSche
               disabled: (specificQuestion as SpecificQuestionConfig).disabled,
               defaultAnswer: (specificQuestion as SpecificQuestionConfig).defaultAnswer,
             },
-            answers: (question.questionOptions.answers ?? []).map((answer) => ({
-              value: answer.concept,
-              display: answer.label ?? conceptLabels[answer.concept]?.display,
-            })),
+            answers,
           };
         }),
     ),

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface SpecificQuestion {
 export interface SpecificQuestionConfig {
   forms: Array<string>;
   questionId: string;
+  answers?: Array<string>;
   defaultAnswer?: string;
   disabled?: boolean;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [] My work includes tests or is validated by existing tests.

## Summary
This PR introduces support for providing a filtered list of specific answers in configurations. Instead of fetching all possible answers for a question, the system now allows explicitly defining and serving a static set of answers.

When the `answers` property is specified, only the IDs listed will be considered as possible answers.

```
{
    "answers": [
        "concept-uuid-1",
        "concept-uuid-2"
    ]
}
```

Concepts labels are still fetched dynamically, requiring no static configuration.

## Screenshots
N/A

## Related Issue
N/A

## Other
Thanks,
