### PR TITLE
(fix) Avoid adding duplicate session obs to obs payload

### DIFF
--- a/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
+++ b/src/group-form-entry-workflow/GroupSessionWorkspace.tsx
@@ -97,7 +97,7 @@ const GroupSessionWorkspace = () => {
       const visitUuid = activeVisitUuid ? activeVisitUuid : uuid();
       if (!activeVisitUuid) {
         Object.entries(groupSessionConcepts).forEach(([field, uuid]) => {
-          if (activeSessionMeta?.[field] != null) {
+          if (activeSessionMeta?.[field] != null && !payload.obs.some((obsItem) => obsItem.concept === uuid)) {
             payload.obs.push({
               concept: uuid,
               value: activeSessionMeta[field],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue in the `handleEncounterCreate` function where concepts from `activeSessionMeta` could be redundantly added to the `obs` payload, leading to duplicates. The function now checks if a concept from `activeSessionMeta` already exists in `payload.obs` before adding it.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
