### PR TITLE
(fix) Prevent "Save & Complete" button from becoming unresponsive

### DIFF
--- a/src/CompleteModal.tsx
+++ b/src/CompleteModal.tsx
@@ -17,7 +17,7 @@ const CompleteModal = ({ open, setOpen, context, validateFirst = false }) => {
   };
 
   return (
-    <ComposedModal open={open}>
+    <ComposedModal open={open} preventCloseOnClickOutside={true} onClose={onCancel}>
       <ModalHeader>{t('areYouSure', 'Are you sure?')}</ModalHeader>
       <ModalBody>{t('saveExplanation', 'Do you want to save the current form and exit the workflow?')}</ModalBody>
       <ModalFooter>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an issue where the "Save & Complete" button becomes unresponsive if the user accidentally clicks outside the confirmation pop-up. Previously, users had to refresh the page to proceed.

## Issue Reproduction Steps and Screenshots

- Open an form/start a session and fill it out.
- If we miss the button complete by mistake and we click above the pop-up disappears
![image](https://github.com/user-attachments/assets/74b42b46-ac51-4e93-8719-d1bc05a81607)
- The Save & Complete button becomes irresponsive
![image](https://github.com/user-attachments/assets/eb2d560b-ed09-4f19-ad98-235b73539025)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Thanks,