### PR TITLE
Add Prompt Before closing State to ExtensionSlot in FormBootstrap Component 

### DIFF
--- a/src/FormBootstrap.tsx
+++ b/src/FormBootstrap.tsx
@@ -157,6 +157,7 @@ const FormBootstrap = ({
             patientUuid,
             patient,
             encounterUuid: encounterUuid ?? '',
+            promptBeforeClosing:()=>undefined,
             closeWorkspace: () => undefined,
             handlePostResponse: (encounter) => {
               handlePostResponse(encounter);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
The React Form Engine expects a promptBeforeClosing function and is determined to check whether the form is dirty. Since this is mostly used in workspaces where we launch clinical forms in patient chart, i have made the function to return undefined here.
## Screenshots
Before
<img width="386" alt="image" src="https://github.com/user-attachments/assets/4e3797d2-eea8-4574-93de-67765f8f7c91" />
After
<img width="385" alt="image" src="https://github.com/user-attachments/assets/32888543-0d9d-42c4-b357-79c4fb46cfa7" />


