### PR TITLE
(feat) Add configuration option to disable group sessions for specific form

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -26,6 +26,11 @@ export const configSchema = {
             _type: Type.String,
             _description: 'Name of form',
           },
+          disableGroupSession: {
+            _type: Type.Boolean,
+            _description: 'Disable group sessions for this form',
+            _default: false,
+          },
         },
       },
     },
@@ -36,6 +41,7 @@ export const configSchema = {
           {
             formUUID: '0cefb866-110c-4f16-af58-560932a1db1f',
             name: 'Adult Triage',
+            disableGroupSession: false,
           },
         ],
       },
@@ -45,6 +51,7 @@ export const configSchema = {
           {
             formUUID: '9f26aad4-244a-46ca-be49-1196df1a8c9a',
             name: 'POC Sample Form 1',
+            disableGroupSession: false,
           },
         ],
       },
@@ -126,6 +133,7 @@ export const configSchema = {
 export type Form = {
   formUUID: Type.UUID;
   name: Type.String;
+  disableGroupSession: Type.Boolean;
 };
 
 export type Category = {

--- a/src/forms-page/forms-table/FormsTable.tsx
+++ b/src/forms-page/forms-table/FormsTable.tsx
@@ -45,7 +45,7 @@ const FormsTable = ({ rows, error, isLoading, activeForms, activeGroupForms }) =
         {activeForms.includes(row.uuid) ? t('resumeSession', 'Resume Session') : t('fillForm', 'Fill Form')}
       </Link>
     ),
-    actions2: (
+    actions2: !row.disableGroupSession && (
       <Link to={`groupform/${row.uuid}`}>
         {activeGroupForms.includes(row.uuid)
           ? t('resumeGroupSession', 'Resume Group Session')


### PR DESCRIPTION
…c form

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This update introduces a configuration option that allows users to disable group sessions for a specific form.
To achieve this, the user must set the disableGroupSession property to true within the form configuration, like so:
```
 "formCategories": [
      {
        "name": "Category One",
        "forms": [
            {
              "formUUID": "valid-form-uuid",
              "name": "My Form"
            },
            {
              "formUUID": "another-form-uuid",
              "name": "My second form",
              "disableGroupSession": true
            }
        ]
      } ...
  ]
 `
## Screenshots

![Pasted Graphic 2](https://github.com/user-attachments/assets/8825b1c1-246e-4f2a-a17f-1d11455f39e9)


This development hides the button to start a group session, which is enough for this use case

## Related Issue

## Other
<!-- Anything not covered above -->
