### PR TITLE
(feat) Confirmation modal when selecting patient outside session location

### DIFF
--- a/src/add-group-modal/AddGroupModal.tsx
+++ b/src/add-group-modal/AddGroupModal.tsx
@@ -160,6 +160,25 @@ const AddGroupModal = ({
     [name, patientList.length],
   );
 
+  const addSelectedPatientToList = useCallback(() => {
+    function getPatientName(patient) {
+      return [patient?.name?.[0]?.given, patient?.name?.[0]?.family].join(' ');
+    }
+    if (!patientList.find((p) => p.uuid === selectedPatientUuid)) {
+      fetchCurrentPatient(selectedPatientUuid).then((result) => {
+        const newPatient = { uuid: selectedPatientUuid, ...result };
+        setPatientList(
+          [...patientList, newPatient].sort((a, b) =>
+            getPatientName(a).localeCompare(getPatientName(b), undefined, {
+              sensitivity: 'base',
+            }),
+          ),
+        );
+      });
+    }
+    setErrors((errors) => ({ ...errors, patientList: null }));
+  }, [selectedPatientUuid, patientList, setPatientList]);
+
   const updatePatientList = (patientUuid) => {
     setSelectedPatientUuid(patientUuid);
   };
@@ -172,7 +191,13 @@ const AddGroupModal = ({
     } else {
       addSelectedPatientToList();
     }
-  }, [selectedPatientUuid, sessionLocation, hsuIdentifier]);
+  }, [
+    selectedPatientUuid,
+    sessionLocation,
+    hsuIdentifier,
+    addSelectedPatientToList,
+    config.patientLocationMismatchCheck,
+  ]);
 
   const handleSubmit = () => {
     if (validate()) {
@@ -220,25 +245,6 @@ const AddGroupModal = ({
       }
     }
   }, [error, t]);
-
-  const addSelectedPatientToList = useCallback(() => {
-    function getPatientName(patient) {
-      return [patient?.name?.[0]?.given, patient?.name?.[0]?.family].join(' ');
-    }
-    if (!patientList.find((p) => p.uuid === selectedPatientUuid)) {
-      fetchCurrentPatient(selectedPatientUuid).then((result) => {
-        const newPatient = { uuid: selectedPatientUuid, ...result };
-        setPatientList(
-          [...patientList, newPatient].sort((a, b) =>
-            getPatientName(a).localeCompare(getPatientName(b), undefined, {
-              sensitivity: 'base',
-            }),
-          ),
-        );
-      });
-    }
-    setErrors((errors) => ({ ...errors, patientList: null }));
-  }, [selectedPatientUuid, patientList, setPatientList]);
 
   const onPatientLocationMismatchModalCancel = () => {
     setSelectedPatientUuid(null);

--- a/src/add-group-modal/AddGroupModal.tsx
+++ b/src/add-group-modal/AddGroupModal.tsx
@@ -167,7 +167,7 @@ const AddGroupModal = ({
   useEffect(() => {
     if (!selectedPatientUuid || !hsuIdentifier) return;
 
-    if (hsuIdentifier && sessionLocation.uuid != hsuIdentifier.location.uuid) {
+    if (config.patientLocationMismatchCheck && hsuIdentifier && sessionLocation.uuid != hsuIdentifier.location.uuid) {
       setPatientLocationMismatchModalOpen(true);
     } else {
       addSelectedPatientToList();

--- a/src/add-group-modal/AddGroupModal.tsx
+++ b/src/add-group-modal/AddGroupModal.tsx
@@ -2,10 +2,19 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import { ComposedModal, Button, ModalHeader, ModalFooter, ModalBody, TextInput, FormLabel } from '@carbon/react';
 import { TrashCan } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, fetchCurrentPatient, showToast, useConfig, usePatient } from '@openmrs/esm-framework';
+import {
+  ExtensionSlot,
+  fetchCurrentPatient,
+  showToast,
+  useConfig,
+  usePatient,
+  useSession,
+} from '@openmrs/esm-framework';
 import styles from './styles.scss';
 import GroupFormWorkflowContext from '../context/GroupFormWorkflowContext';
 import { usePostCohort } from '../hooks';
+import PatientLocationMismatchModal from '../form-entry-workflow/patient-search-header/PatienMismatchedLocationModal';
+import { useHsuIdIdentifier } from '../hooks/location-tag.resource';
 
 const MemExtension = React.memo(ExtensionSlot);
 
@@ -112,6 +121,10 @@ const AddGroupModal = ({
   const [patientList, setPatientList] = useState(patients || []);
   const { post, result, error } = usePostCohort();
   const config = useConfig();
+  const [patientLocationMismatchModalOpen, setPatientLocationMismatchModalOpen] = useState(false);
+  const [selectedPatientUuid, setSelectedPatientUuid] = useState();
+  const { hsuIdentifier } = useHsuIdIdentifier(selectedPatientUuid);
+  const { sessionLocation } = useSession();
 
   const removePatient = useCallback(
     (patientUuid: string) =>
@@ -147,27 +160,19 @@ const AddGroupModal = ({
     [name, patientList.length],
   );
 
-  const updatePatientList = useCallback(
-    (patientUuid) => {
-      function getPatientName(patient) {
-        return [patient?.name?.[0]?.given, patient?.name?.[0]?.family].join(' ');
-      }
-      if (!patientList.find((p) => p.uuid === patientUuid)) {
-        fetchCurrentPatient(patientUuid).then((result) => {
-          const newPatient = { uuid: patientUuid, ...result };
-          setPatientList(
-            [...patientList, newPatient].sort((a, b) =>
-              getPatientName(a).localeCompare(getPatientName(b), undefined, {
-                sensitivity: 'base',
-              }),
-            ),
-          );
-        });
-      }
-      setErrors((errors) => ({ ...errors, patientList: null }));
-    },
-    [patientList, setPatientList],
-  );
+  const updatePatientList = (patientUuid) => {
+    setSelectedPatientUuid(patientUuid);
+  };
+
+  useEffect(() => {
+    if (!selectedPatientUuid || !hsuIdentifier) return;
+
+    if (hsuIdentifier && sessionLocation.uuid != hsuIdentifier.location.uuid) {
+      setPatientLocationMismatchModalOpen(true);
+    } else {
+      addSelectedPatientToList();
+    }
+  }, [selectedPatientUuid, sessionLocation, hsuIdentifier]);
 
   const handleSubmit = () => {
     if (validate()) {
@@ -216,33 +221,66 @@ const AddGroupModal = ({
     }
   }, [error, t]);
 
+  const addSelectedPatientToList = useCallback(() => {
+    function getPatientName(patient) {
+      return [patient?.name?.[0]?.given, patient?.name?.[0]?.family].join(' ');
+    }
+    if (!patientList.find((p) => p.uuid === selectedPatientUuid)) {
+      fetchCurrentPatient(selectedPatientUuid).then((result) => {
+        const newPatient = { uuid: selectedPatientUuid, ...result };
+        setPatientList(
+          [...patientList, newPatient].sort((a, b) =>
+            getPatientName(a).localeCompare(getPatientName(b), undefined, {
+              sensitivity: 'base',
+            }),
+          ),
+        );
+      });
+    }
+    setErrors((errors) => ({ ...errors, patientList: null }));
+  }, [selectedPatientUuid, patientList, setPatientList]);
+
+  const onPatientLocationMismatchModalCancel = () => {
+    setSelectedPatientUuid(null);
+  };
+
   return (
-    <div className={styles.modal}>
-      <ComposedModal open={isOpen} onClose={handleCancel}>
-        <ModalHeader>{isCreate ? t('createNewGroup', 'Create New Group') : t('editGroup', 'Edit Group')}</ModalHeader>
-        <ModalBody>
-          <NewGroupForm
-            {...{
-              name,
-              setName,
-              patientList,
-              updatePatientList,
-              errors,
-              validate,
-              removePatient,
-            }}
-          />
-        </ModalBody>
-        <ModalFooter>
-          <Button kind="secondary" onClick={handleCancel}>
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button kind="primary" onClick={handleSubmit}>
-            {isCreate ? t('createGroup', 'Create Group') : t('save', 'Save')}
-          </Button>
-        </ModalFooter>
-      </ComposedModal>
-    </div>
+    <>
+      <div className={styles.modal}>
+        <ComposedModal open={isOpen} onClose={handleCancel}>
+          <ModalHeader>{isCreate ? t('createNewGroup', 'Create New Group') : t('editGroup', 'Edit Group')}</ModalHeader>
+          <ModalBody>
+            <NewGroupForm
+              {...{
+                name,
+                setName,
+                patientList,
+                updatePatientList,
+                errors,
+                validate,
+                removePatient,
+              }}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button kind="secondary" onClick={handleCancel}>
+              {t('cancel', 'Cancel')}
+            </Button>
+            <Button kind="primary" onClick={handleSubmit}>
+              {isCreate ? t('createGroup', 'Create Group') : t('save', 'Save')}
+            </Button>
+          </ModalFooter>
+        </ComposedModal>
+      </div>
+      <PatientLocationMismatchModal
+        open={patientLocationMismatchModalOpen}
+        setOpen={setPatientLocationMismatchModalOpen}
+        onConfirm={addSelectedPatientToList}
+        onCancel={onPatientLocationMismatchModalCancel}
+        sessionLocation={sessionLocation}
+        hsuLocation={hsuIdentifier?.location}
+      />
+    </>
   );
 };
 

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -128,6 +128,12 @@ export const configSchema = {
     },
     _default: [],
   },
+  patientLocationMismatchCheck: {
+    _type: Type.Boolean,
+    _description:
+      'Whether to prompt for confirmation if the selected patient is not at the same location as the current session.',
+    _default: false,
+  },
 };
 
 export type Form = {
@@ -144,4 +150,5 @@ export type Category = {
 export type Config = {
   formCategories: Array<Category>;
   formCategoriesToShow: Array<string>;
+  patientLocationMismatchCheck: Type.Boolean;
 };

--- a/src/form-entry-workflow/FormEntryWorkflow.tsx
+++ b/src/form-entry-workflow/FormEntryWorkflow.tsx
@@ -73,7 +73,7 @@ const FormWorkspace = () => {
 
   useEffect(() => {
     if (encounter && visit) {
-      // Update encounter so that it belongs to the created visit
+      // Update the encounter so that it belongs to the created visit
       updateEncounter({ uuid: encounter.uuid, visit: visit.uuid });
     }
   }, [encounter, visit, updateEncounter]);

--- a/src/form-entry-workflow/patient-search-header/PatienMismatchedLocationModal.tsx
+++ b/src/form-entry-workflow/patient-search-header/PatienMismatchedLocationModal.tsx
@@ -2,7 +2,7 @@ import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from '@car
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-const PatientMismatchedLocationModal = ({ open, setOpen, onConfirm, onCancel, sessionLocation, hsuLocation }) => {
+const PatientLocationMismatchModal = ({ open, setOpen, onConfirm, onCancel, sessionLocation, hsuLocation }) => {
   const { t } = useTranslation();
 
   const hsuDisplay = hsuLocation?.display || t('unknown', 'Unknown');
@@ -43,4 +43,4 @@ const PatientMismatchedLocationModal = ({ open, setOpen, onConfirm, onCancel, se
   );
 };
 
-export default PatientMismatchedLocationModal;
+export default PatientLocationMismatchModal;

--- a/src/form-entry-workflow/patient-search-header/PatienMismatchedLocationModal.tsx
+++ b/src/form-entry-workflow/patient-search-header/PatienMismatchedLocationModal.tsx
@@ -1,0 +1,46 @@
+import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const PatientMismatchedLocationModal = ({ open, setOpen, onConfirm, onCancel, sessionLocation, hsuLocation }) => {
+  const { t } = useTranslation();
+
+  const hsuDisplay = hsuLocation?.display || t('unknown', 'Unknown');
+  const sessionDisplay = sessionLocation?.display || t('unknown', 'Unknown');
+
+  const handleCancel = () => {
+    onCancel?.();
+    setOpen(false);
+  };
+
+  const handleConfirm = () => {
+    onConfirm?.();
+    setOpen(false);
+  };
+
+  return (
+    <ComposedModal open={open}>
+      <ModalHeader>{t('confirmPatientSelection', 'Confirm patient selection')}</ModalHeader>
+      <ModalBody>
+        {t(
+          'patientLocationMismatch',
+          `The selected HSU location (${hsuLocation}) does not match the current session location (${sessionLocation}). Are you sure you want to proceed?`,
+          {
+            hsuLocation: hsuDisplay,
+            sessionLocation: sessionDisplay,
+          },
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={handleCancel}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button kind="primary" onClick={handleConfirm}>
+          {t('continue', 'Continue')}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};
+
+export default PatientMismatchedLocationModal;

--- a/src/form-entry-workflow/patient-search-header/PatientSearchHeader.tsx
+++ b/src/form-entry-workflow/patient-search-header/PatientSearchHeader.tsx
@@ -1,19 +1,20 @@
 import { Add, Close } from '@carbon/react/icons';
-import { ExtensionSlot, interpolateUrl, navigate, useSession } from '@openmrs/esm-framework';
+import { ExtensionSlot, interpolateUrl, navigate, useConfig, useSession } from '@openmrs/esm-framework';
 import { Button } from '@carbon/react';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import FormWorkflowContext from '../../context/FormWorkflowContext';
 import styles from './styles.scss';
 import { useTranslation } from 'react-i18next';
-import PatientMismatchedLocationModal from './PatienMismatchedLocationModal';
 import { useHsuIdIdentifier } from '../../hooks/location-tag.resource';
+import PatientLocationMismatchModal from './PatienMismatchedLocationModal';
 
 const PatientSearchHeader = () => {
   const [patientLocationMismatchModalOpen, setPatientLocationMismatchModalOpen] = useState(false);
   const [selectedPatientUuid, setSelectedPatientUuid] = useState();
   const { hsuIdentifier } = useHsuIdIdentifier(selectedPatientUuid);
   const { sessionLocation } = useSession();
+  const config = useConfig();
 
   const onPatientMismatchedLocationModalConfirm = useCallback(() => {
     addPatient(selectedPatientUuid);
@@ -34,7 +35,7 @@ const PatientSearchHeader = () => {
   useEffect(() => {
     if (!selectedPatientUuid || !hsuIdentifier) return;
 
-    if (hsuIdentifier && sessionLocation.uuid != hsuIdentifier.location.uuid) {
+    if (config.patientLocationMismatchCheck && hsuIdentifier && sessionLocation.uuid != hsuIdentifier.location.uuid) {
       setPatientLocationMismatchModalOpen(true);
     } else {
       addPatient(selectedPatientUuid);
@@ -78,7 +79,7 @@ const PatientSearchHeader = () => {
           </Link>
         </span>
       </div>
-      <PatientMismatchedLocationModal
+      <PatientLocationMismatchModal
         open={patientLocationMismatchModalOpen}
         setOpen={setPatientLocationMismatchModalOpen}
         onConfirm={onPatientMismatchedLocationModalConfirm}

--- a/src/form-entry-workflow/patient-search-header/PatientSearchHeader.tsx
+++ b/src/form-entry-workflow/patient-search-header/PatientSearchHeader.tsx
@@ -15,18 +15,17 @@ const PatientSearchHeader = () => {
   const { hsuIdentifier } = useHsuIdIdentifier(selectedPatientUuid);
   const { sessionLocation } = useSession();
   const config = useConfig();
+  const { addPatient, workflowState, activeFormUuid } = useContext(FormWorkflowContext);
 
   const onPatientMismatchedLocationModalConfirm = useCallback(() => {
     addPatient(selectedPatientUuid);
     setSelectedPatientUuid(null);
-  }, [selectedPatientUuid]);
+  }, [addPatient, selectedPatientUuid]);
 
   const onPatientMismatchedLocationModalCancel = useCallback(() => {
     setPatientLocationMismatchModalOpen(false);
     setSelectedPatientUuid(null);
   }, []);
-
-  const { addPatient, workflowState, activeFormUuid } = useContext(FormWorkflowContext);
 
   const handleSelectPatient = useCallback((patientUuid) => {
     setSelectedPatientUuid(patientUuid);
@@ -40,7 +39,7 @@ const PatientSearchHeader = () => {
     } else {
       addPatient(selectedPatientUuid);
     }
-  }, [selectedPatientUuid, sessionLocation, hsuIdentifier]);
+  }, [selectedPatientUuid, sessionLocation, hsuIdentifier, addPatient, config.patientLocationMismatchCheck]);
 
   const { t } = useTranslation();
 

--- a/src/hooks/location-tag.resource.ts
+++ b/src/hooks/location-tag.resource.ts
@@ -1,0 +1,33 @@
+import useSWR from 'swr';
+import { openmrsFetch } from '@openmrs/esm-framework';
+
+export interface Identifier {
+  uuid: string;
+  identifier: string;
+  display: string;
+  identifierType: {
+    uuid: string;
+    display: string;
+  };
+  location: {
+    uuid: string;
+    display: string;
+  };
+}
+
+export function useHsuIdIdentifier(patientUuid: string) {
+  const hsuIdType = '05a29f94-c0ed-11e2-94be-8c13b969e334';
+  const url = patientUuid ? `ws/rest/v1/patient/${patientUuid}/identifier` : null;
+  const { data, error, isValidating } = useSWR<{ data: { results: Array<Identifier> } }, Error>(url, openmrsFetch);
+
+  const hsuIdentifier = data?.data?.results.length
+    ? data.data.results.find((id: Identifier) => id.identifierType.uuid == hsuIdType)
+    : undefined;
+
+  return {
+    hsuIdentifier: hsuIdentifier,
+    isLoading: !data && !error,
+    isError: error,
+    isValidating,
+  };
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -9,6 +9,8 @@
   "chooseGroupError": "Please choose a group.",
   "clearSearch": "Clear",
   "complete": "Complete",
+  "confirmPatientSelection": "Confirm patient selection",
+  "continue": "Continue",
   "createGroup": "Create Group",
   "createNewGroup": "Create New Group",
   "createNewPatient": "Create new patient",
@@ -41,6 +43,7 @@
   "or": "or",
   "orLabelName": "OR label name",
   "patientIsPresent": "Patient is present",
+  "patientLocationMismatch": "The selected HSU location ({{hsuLocation}}) does not match the current session location ({{sessionLocation}}). Are you sure you want to proceed?",
   "patientsInGroup": "Patients in group",
   "postError": "POST Error",
   "practitionerName": "Practitioner Name",
@@ -71,7 +74,5 @@
   "startGroupSession": "Start Group Session",
   "trySearchWithPatientUniqueID": "Try searching with the cohort's description",
   "unknown": "Unknown",
-  "unknownPostError": "An unknown error occurred while saving data",
-  "confirmPatientSelection": "Confirm patient selection",
-  "patientLocationMismatch": "The selected HSU location ({{hsuLocation}}) does not match the current session location ({{sessionLocation}}). Are you sure you want to proceed?"
+  "unknownPostError": "An unknown error occurred while saving data"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -71,5 +71,7 @@
   "startGroupSession": "Start Group Session",
   "trySearchWithPatientUniqueID": "Try searching with the cohort's description",
   "unknown": "Unknown",
-  "unknownPostError": "An unknown error occurred while saving data"
+  "unknownPostError": "An unknown error occurred while saving data",
+  "confirmPatientSelection": "Confirm patient selection",
+  "patientLocationMismatch": "The selected HSU location ({{hsuLocation}}) does not match the current session location ({{sessionLocation}}). Are you sure you want to proceed?"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -9,6 +9,8 @@
   "chooseGroupError": "Por favor, elige un grupo.",
   "clearSearch": "Limpiar",
   "complete": "Completar",
+  "confirmPatientSelection": "Confirmar la selección del paciente",
+  "continue": "Continue",
   "createGroup": "Crear Grupo",
   "createNewGroup": "Crear Nuevo Grupo",
   "createNewPatient": "Crear nuevo paciente",
@@ -41,6 +43,7 @@
   "or": "o",
   "orLabelName": "Nombre de Etiqueta OR",
   "patientIsPresent": "Paciente está presente",
+  "patientLocationMismatch": "La ubicación de HSU seleccionada ({{hsuLocation}}) no coincide con la ubicación de la sesión actual ({{sessionLocation}}). ¿Está seguro de que desea continuar?",
   "patientsInGroup": "Pacientes en el grupo",
   "postError": "Error de POST",
   "practitionerName": "Nombre del Practicante",
@@ -71,7 +74,5 @@
   "startGroupSession": "Iniciar Sesión de Grupo",
   "trySearchWithPatientUniqueID": "Intente buscar con la descripción del grupo",
   "unknown": "Desconocido",
-  "unknownPostError": "Ocurrió un error desconocido al guardar los datos",
-  "confirmPatientSelection": "Confirmar la selección del paciente",
-  "patientLocationMismatch": "La ubicación de HSU seleccionada ({{hsuLocation}}) no coincide con la ubicación de la sesión actual ({{sessionLocation}}). ¿Está seguro de que desea continuar?"
+  "unknownPostError": "Ocurrió un error desconocido al guardar los datos"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -71,5 +71,7 @@
   "startGroupSession": "Iniciar Sesión de Grupo",
   "trySearchWithPatientUniqueID": "Intente buscar con la descripción del grupo",
   "unknown": "Desconocido",
-  "unknownPostError": "Ocurrió un error desconocido al guardar los datos"
+  "unknownPostError": "Ocurrió un error desconocido al guardar los datos",
+  "confirmPatientSelection": "Confirmar la selección del paciente",
+  "patientLocationMismatch": "La ubicación de HSU seleccionada ({{hsuLocation}}) no coincide con la ubicación de la sesión actual ({{sessionLocation}}). ¿Está seguro de que desea continuar?"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -9,6 +9,8 @@
   "chooseGroupError": "Veuillez sélectionner un groupe",
   "clearSearch": "Clair",
   "complete": "Terminer",
+  "confirmPatientSelection": "Confirmer la sélection du patient",
+  "continue": "Continue",
   "createGroup": "Créer un groupe",
   "createNewGroup": "Créer un nouveau groupe",
   "createNewPatient": "Créer un nouveau patient",
@@ -41,6 +43,7 @@
   "or": "ou",
   "orLabelName": "OU nom de l'étiquette",
   "patientIsPresent": "Le patient est présent",
+  "patientLocationMismatch": "L'emplacement HSU sélectionné ({{hsuLocation}}) ne correspond pas à l'emplacement de la session actuelle ({{sessionLocation}}). Voulez-vous vraiment continuer\u00a0?",
   "patientsInGroup": "Patients dans le groupe",
   "postError": "Erreur de POST",
   "practitionerName": "Nom du praticien",
@@ -71,7 +74,5 @@
   "startGroupSession": "Démarrer la session de groupe",
   "trySearchWithPatientUniqueID": "Essayez de rechercher la description de la cohorte",
   "unknown": "Inconnu",
-  "unknownPostError": "Une erreur inconnue s'est produite lors de la sauvegarde des données",
-  "confirmPatientSelection": "Confirmer la sélection du patient",
-  "patientLocationMismatch": "L'emplacement HSU sélectionné ({{hsuLocation}}) ne correspond pas à l'emplacement de la session actuelle ({{sessionLocation}}). Voulez-vous vraiment continuer ?"
+  "unknownPostError": "Une erreur inconnue s'est produite lors de la sauvegarde des données"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -71,5 +71,7 @@
   "startGroupSession": "Démarrer la session de groupe",
   "trySearchWithPatientUniqueID": "Essayez de rechercher la description de la cohorte",
   "unknown": "Inconnu",
-  "unknownPostError": "Une erreur inconnue s'est produite lors de la sauvegarde des données"
+  "unknownPostError": "Une erreur inconnue s'est produite lors de la sauvegarde des données",
+  "confirmPatientSelection": "Confirmer la sélection du patient",
+  "patientLocationMismatch": "L'emplacement HSU sélectionné ({{hsuLocation}}) ne correspond pas à l'emplacement de la session actuelle ({{sessionLocation}}). Voulez-vous vraiment continuer ?"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Displays a warning modal if the selected HSU location does not match the current session location.
Allows the user to confirm or cancel their selection.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
