### PR TITLE
(fix) Correct patient location mismatch prompt behavior in group management

### DIFF
--- a/src/add-group-modal/AddGroupModal.tsx
+++ b/src/add-group-modal/AddGroupModal.tsx
@@ -177,6 +177,7 @@ const AddGroupModal = ({
       });
     }
     setErrors((errors) => ({ ...errors, patientList: null }));
+    setSelectedPatientUuid(null);
   }, [selectedPatientUuid, patientList, setPatientList]);
 
   const updatePatientList = (patientUuid) => {
@@ -186,7 +187,7 @@ const AddGroupModal = ({
   useEffect(() => {
     if (!selectedPatientUuid || !hsuIdentifier) return;
 
-    if (config.patientLocationMismatchCheck && hsuIdentifier && sessionLocation.uuid != hsuIdentifier.location.uuid) {
+    if (config.patientLocationMismatchCheck && sessionLocation.uuid != hsuIdentifier.location.uuid) {
       setPatientLocationMismatchModalOpen(true);
     } else {
       addSelectedPatientToList();

--- a/src/form-entry-workflow/patient-search-header/PatienMismatchedLocationModal.tsx
+++ b/src/form-entry-workflow/patient-search-header/PatienMismatchedLocationModal.tsx
@@ -19,7 +19,7 @@ const PatientLocationMismatchModal = ({ open, setOpen, onConfirm, onCancel, sess
   };
 
   return (
-    <ComposedModal open={open}>
+    <ComposedModal open={open} onClose={handleCancel}>
       <ModalHeader>{t('confirmPatientSelection', 'Confirm patient selection')}</ModalHeader>
       <ModalBody>
         {t(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an issue where the prompt for a patient location mismatch was not functioning correctly when managing session patient groups.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
