### PR TITLE
(chore) O3-5867: Add @carbon/react and @carbon/icons-react to peerDependencies in openmrs-esm-fast-data-entry-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-fast-data-entry-app/issues"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "11.x",
     "@carbon/react": "1.x",
     "@openmrs/esm-framework": "10.x",
     "lodash-es": "4.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3434,6 +3434,7 @@ __metadata:
     uuid: "npm:^9.0.1"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": 11.x
     "@carbon/react": 1.x
     "@openmrs/esm-framework": 10.x
     lodash-es: 4.x


### PR DESCRIPTION


## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates `openmrs-esm-fast-data-entry-app` to declare `@carbon/react` and `@carbon/icons-react` as `peerDependencies`, matching the versions provided by the OpenMRS shell. Previously, because these packages were not listed in `peerDependencies`, the app bundled its own copies of Carbon React and Carbon Icons, resulting in duplicated frontend bundles and unnecessary runtime-loaded chunks. Since Module Federation derives the `shared` list from `peerDependencies`, omitting these packages prevented the app from using the shell-provided singleton instances.

By adding both packages to `peerDependencies`, this change enables Module Federation to share the shell-provided singletons, reducing duplicate bundle size and improving frontend loading efficiency while keeping existing functionality and tests unchanged.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/issues?filter=-1&selectedIssue=O3-5867

## Other
<!-- Anything not covered above -->
